### PR TITLE
Update postprocessing pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The pipeline runs the following steps in order:
 |---|---|
 | `uncompress` | Extract compressed submission archives |
 | `symlinks` | Parse filenames and create typed symlink directories |
+| `check_planned` | Check extracted experiments against planned experiment |
 | `point2dem` | Convert dense point clouds to DEMs via PDAL |
 | `coregister` | Coregister DEMs to the reference (Nuth–Kaab + vertical shift) |
 | `ddem` | Compute differential DEMs before and after coregistration |

--- a/environment.yml
+++ b/environment.yml
@@ -14,8 +14,10 @@ dependencies:
   - humanize
   - ruff
   - pdal
-  - pip
+  - plotly  # For Sankey diagram
   - gdown
+  - pip
   - pip :
     - usgsxplore
     - hipp==0.2.0
+    - kaleido  # for sankey export

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - ruff
   - pdal
   - pip
+  - gdown
   - pip :
     - usgsxplore
     - hipp==0.2.0

--- a/scripts/check_submissions.py
+++ b/scripts/check_submissions.py
@@ -6,7 +6,7 @@ from typing import Any
 
 # Defines the expected segments in the filename, separated by _
 SEGMENT_SPECS_v2 = [
-    ("author", r"[A-Za-z0-9]{3,5}", "exactly 3 or 4 alphanumeric characters"),
+    ("author", r"[A-Za-z0-9]{3,6}", "3 to 6 alphanumeric characters"),
     ("site", r"(?:CG|IL)", "either 'CG' or 'IL'"),
     ("dataset", r"(?:AI|MC|PC)", "either AI, MC or PC"),
     ("images", r"(?:PP|RA)", "either 'PP' or 'RA'"),

--- a/scripts/create_sankey_diagram.py
+++ b/scripts/create_sankey_diagram.py
@@ -1,0 +1,88 @@
+from check_submissions import parse_filename
+import pandas as pd
+import sankey
+
+
+# Load CSV and remove empty lines
+experiments_df = pd.read_csv("planned_experiments2.csv", delimiter=";")
+experiments_df = experiments_df[~experiments_df["Submission code"].isna()]
+
+# Extract experiment codes from experiment names
+fname = experiments_df["Submission code"][0] + "_intrinsics"
+code, metadata = parse_filename(fname)
+
+df_columns = list(metadata.keys()) + ["software"]
+exp_metadata = pd.DataFrame(columns=df_columns)
+
+for i, row in experiments_df.iterrows():
+    exp_name = row["Submission code"]
+    fname = exp_name + "_intrinsics.csv"  # Need to add suffix for parse_filename to work
+    try:
+        code, metadata = parse_filename(fname)
+    except ValueError as e:
+        print(exp_name, e)
+
+    metadata["software"] = row["Stereo software"]
+    exp_metadata.loc[len(exp_metadata)] = metadata
+
+# fig = dataframe_to_sankey(
+#     exp_metadata,
+#     # columns=["dataset", "georef", "mtp_adjustments"],
+#     columns=["dataset", "georef", "mtp_adjustments", "software"],
+#     output_file="experiment_sankey.png",
+#     title="Sankey diagram",
+#     edge_color=None,
+# )
+# fig.show()
+
+custom_palette = [
+    "#DE8F05",
+    "#0173B2",
+    "#029E73",
+    "#D55E00", "#CC78BC",
+    "#CA9161", "#FBAFE4", 
+    "#ECE133", "#56B4E9"
+]
+
+# Matplotlib tab20 palette
+tab20_palette = [
+"#1f77b4","#aec7e8","#ff7f0e","#ffbb78","#2ca02c","#98df8a","#d62728","#ff9896","#9467bd","#c5b0d5",
+"#8c564b","#c49c94","#e377c2","#f7b6d2","#7f7f7f","#c7c7c7","#bcbd22","#dbdb8d","#17becf","#9edae5",
+]
+
+# Matplotlib tab20 palette customized
+software_dataset_palette = [
+"#d62728","#ff9896","#9467bd","#c5b0d5","#8c564b","#c49c94","#e377c2","#f7b6d2",
+"#ff7f0e", "#1f77b4","#2ca02c"
+]
+
+software_dataset_palette = [
+"#d62728","#ff9896","#9467bd","#c5b0d5","#17becf","#9edae5","#bcbd22","#dbdb8d",
+"#ff7f0e", "#1f77b4","#2ca02c"
+]
+
+# fig = sankey.dataframe_to_sankey(
+#     exp_metadata,
+#     # columns=["dataset", "georef", "mtp_adjustments"],
+#     columns=["dataset", "georef", "mtp_adjustments", "software"],
+#     columns_label=["Dataset", "Georef. strategy", "Multitemp BBA", "Software"],
+#     output_file="experiment_sankey.png",
+#     palette=custom_palette,
+#     title="",
+#     force_color={"software": "#B0B0B0"},
+#     font_size=22,
+# )
+# fig.show()
+
+fig = sankey.dataframe_to_sankey(
+    exp_metadata,
+    columns=["software", "dataset", "georef"],
+    output_file="experiment_sankey2.png",
+    title="",
+    force_color={"georef": "#B0B0B0"},
+    columns_label=["Software", "Dataset", "Georef. strategy"],
+    font_size=24,
+    palette=software_dataset_palette,
+    alpha=0.6,
+)
+fig.show()

--- a/src/history/postprocessing/cli.py
+++ b/src/history/postprocessing/cli.py
@@ -264,6 +264,7 @@ def _run_generate_pdf(config: Config) -> None:
         plot_dir=config.plot_dir,
         filename_renames=config.filename_renames,
         orientation=config.pdf_orientation,
+        overwrite=config.overwrite,
     )
 
 

--- a/src/history/postprocessing/cli.py
+++ b/src/history/postprocessing/cli.py
@@ -201,6 +201,7 @@ def _run_coregister(config: Config) -> None:
     )
 
     if not config.no_plots:
+        logger.info("Plotting coregistered DEMs mosaics and figures")
         plot_coregistration(config)
 
 

--- a/src/history/postprocessing/cli.py
+++ b/src/history/postprocessing/cli.py
@@ -118,8 +118,9 @@ def cmd_create(args: argparse.Namespace) -> None:
 
 def _run_uncompress(config: Config) -> None:
     """Extract all compressed submission archives into the extracted directory."""
-    from history.postprocessing.pipeline import uncompress_all_submissions
+    from history.postprocessing.pipeline import uncompress_all_submissions, cleanup_orphaned_extracted
 
+    cleanup_orphaned_extracted(config.raw_dir, config.extracted_dir)
     uncompress_all_submissions(
         config.raw_dir,
         config.extracted_dir,
@@ -154,8 +155,10 @@ def _run_check_planned(config: Config) -> None:
 
 def _run_point2dem(config: Config) -> None:
     """Convert dense point clouds to DEMs via PDAL, and integrate any user-provided DEMs."""
-    from history.postprocessing.pipeline import process_pointclouds_to_dems, add_provided_dems, plot_point2dem
+    from history.postprocessing.pipeline import process_pointclouds_to_dems, add_provided_dems, plot_point2dem, cleanup_orphaned_raw_dems
     from history.utils import log_to_file
+
+    cleanup_orphaned_raw_dems(config.proc_dir.raw_dems_dir, config.proc_dir.symlinks_dir)
 
     dense_pc_dir = config.proc_dir.symlinks_dir / "dense_pointclouds"
     pointcloud_files = list(dense_pc_dir.glob("*.las")) + list(dense_pc_dir.glob("*.laz"))
@@ -192,7 +195,9 @@ def _run_point2dem(config: Config) -> None:
 
 def _run_coregister(config: Config) -> None:
     """Coregister raw DEMs to the reference using Nuth–Kaab + vertical shift."""
-    from history.postprocessing.pipeline import coregister_dems, plot_coregistration
+    from history.postprocessing.pipeline import coregister_dems, plot_coregistration, cleanup_orphaned_coreg_dems
+
+    cleanup_orphaned_coreg_dems(config.proc_dir.coreg_dems_dir, config.proc_dir.raw_dems_dir)
 
     coregister_dems(
         dem_files=list(config.proc_dir.raw_dems_dir.glob("*-DEM.tif")),
@@ -209,7 +214,10 @@ def _run_coregister(config: Config) -> None:
 
 def _run_ddem(config: Config) -> None:
     """Compute differential DEMs against the reference, before and after coregistration."""
-    from history.postprocessing.pipeline import generate_ddems, plot_ddems
+    from history.postprocessing.pipeline import generate_ddems, plot_ddems, cleanup_orphaned_ddems
+
+    cleanup_orphaned_ddems(config.proc_dir.before_coreg_ddems_dir, config.proc_dir.raw_dems_dir)
+    cleanup_orphaned_ddems(config.proc_dir.after_coreg_ddems_dir, config.proc_dir.coreg_dems_dir)
 
     generate_ddems(
         dem_files=list(config.proc_dir.raw_dems_dir.glob("*-DEM.tif")),

--- a/src/history/postprocessing/cli.py
+++ b/src/history/postprocessing/cli.py
@@ -44,8 +44,30 @@ RUN_STEPS = ["uncompress", "symlinks", "check_planned", "point2dem", "coregister
 
 def _configure_logging(verbosity: int) -> None:
     """Set the ``history`` logger level based on the ``-v`` / ``-vv`` count."""
+    import os
+
     level = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}.get(verbosity, logging.DEBUG)
-    logging.basicConfig(format="%(asctime)s [%(levelname)s] %(name)s: %(message)s", datefmt="%H:%M:%S", stream=sys.stderr)
+    fmt = logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s", datefmt="%H:%M:%S")
+
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setFormatter(fmt)
+
+    root = logging.getLogger()
+    root.addHandler(stdout_handler)
+
+    # Only add a separate stderr handler when stdout and stderr go to different places (e.g. Slurm).
+    # In an interactive terminal both point to the same fd, which would cause duplicates.
+    try:
+        stdout_stderr_differ = os.fstat(sys.stdout.fileno()) != os.fstat(sys.stderr.fileno())
+    except Exception:
+        stdout_stderr_differ = False
+
+    if stdout_stderr_differ:
+        stderr_handler = logging.StreamHandler(sys.stderr)
+        stderr_handler.setFormatter(fmt)
+        stderr_handler.setLevel(logging.WARNING)
+        root.addHandler(stderr_handler)
+
     logging.getLogger("history").setLevel(level)
 
 

--- a/src/history/postprocessing/cli.py
+++ b/src/history/postprocessing/cli.py
@@ -261,7 +261,6 @@ def build_parser() -> argparse.ArgumentParser:
         Parser with two subcommands: ``create`` and ``run``.
     """
     parser = argparse.ArgumentParser(prog="history-postprocess", description="Postprocessing")
-    parser.add_argument("-v", "--verbose", action="count", default=0, help="Increase verbosity (-v INFO, -vv DEBUG)")
 
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -283,6 +282,8 @@ def build_parser() -> argparse.ArgumentParser:
                             help="Skip plot generation for this step")
     run_parser.add_argument("--max-workers", type=int, default=None, metavar="N", dest="max_workers",
                             help="Number of parallel workers (overrides config)")
+    run_parser.add_argument("-v", "--verbose", action="count", default=0, help="Increase verbosity (-v INFO, -vv DEBUG)")
+
     run_parser.set_defaults(func=cmd_run)
 
     return parser

--- a/src/history/postprocessing/cli.py
+++ b/src/history/postprocessing/cli.py
@@ -34,6 +34,7 @@ import shutil
 import sys
 from pathlib import Path
 from history.postprocessing.config import Config
+from history.postprocessing.pipeline import report_symlinks
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +131,7 @@ def _run_symlinks(config: Config) -> None:
     df = io.scan_submissions(config.extracted_dir, filename_renames=config.filename_renames)
     io.validate_submissions(df)
     create_symlinks(df, config.proc_dir.symlinks_dir, overwrite=config.overwrite)
+    report_symlinks(config)
 
     if not config.no_plots:
         plot_symlinks(config, submissions_df=df)

--- a/src/history/postprocessing/cli.py
+++ b/src/history/postprocessing/cli.py
@@ -82,6 +82,8 @@ def _load_config(args: argparse.Namespace) -> Config:
     overrides = {}
     if args.overwrite:
         overrides["overwrite"] = True
+    if args.overwrite_plots:
+        overrides["overwrite_plots"] = True
     if args.dry_run:
         overrides["dry_run"] = True
     if args.no_plots:
@@ -324,7 +326,9 @@ def build_parser() -> argparse.ArgumentParser:
                             help=f"Step to run: {{{', '.join(RUN_STEPS)}}}")
     run_parser.add_argument("--config", required=True, metavar="PATH", help="Path to config.toml")
     run_parser.add_argument("--overwrite", action="store_true", default=False,
-                            help="Force overwrite of existing outputs (overrides config)")
+                            help="Force recompute of existing data outputs (overrides config)")
+    run_parser.add_argument("--overwrite-plots", action="store_true", default=False, dest="overwrite_plots",
+                            help="Force regeneration of existing plots (overrides config)")
     run_parser.add_argument("--dry-run", action="store_true", default=False, dest="dry_run",
                             help="Print actions without executing them (overrides config)")
     run_parser.add_argument("--no-plots", action="store_true", default=False, dest="no_plots",

--- a/src/history/postprocessing/cli.py
+++ b/src/history/postprocessing/cli.py
@@ -126,30 +126,35 @@ def _run_check_planned(config: Config) -> None:
 def _run_point2dem(config: Config) -> None:
     """Convert dense point clouds to DEMs via PDAL, and integrate any user-provided DEMs."""
     from history.postprocessing.pipeline import process_pointclouds_to_dems, add_provided_dems, plot_point2dem
+    from history.utils import log_to_file
 
     dense_pc_dir = config.proc_dir.symlinks_dir / "dense_pointclouds"
     pointcloud_files = list(dense_pc_dir.glob("*.las")) + list(dense_pc_dir.glob("*.laz"))
 
-    process_pointclouds_to_dems(
-        pointcloud_files=pointcloud_files,
-        output_directory=config.proc_dir.raw_dems_dir,
-        references_data=config.references_data_mapping,
-        pdal_exec_path=config.pdal_exec_path,
-        overwrite=config.overwrite,
-        dry_run=config.dry_run,
-        max_workers=config.max_workers,
-    )
+    logs_dir = config.proc_dir.raw_dems_dir / "logs"
+    with log_to_file(logs_dir, logging.getLogger("history.postprocessing")) as log_path:
+        process_pointclouds_to_dems(
+            pointcloud_files=pointcloud_files,
+            output_directory=config.proc_dir.raw_dems_dir,
+            references_data=config.references_data_mapping,
+            pdal_exec_path=config.pdal_exec_path,
+            overwrite=config.overwrite,
+            dry_run=config.dry_run,
+            max_workers=config.max_workers,
+        )
 
-    dems_symlink_dir = config.proc_dir.symlinks_dir / "dems"
-    if dems_symlink_dir.exists():
-        dem_files = list(dems_symlink_dir.glob("*.tif"))
-        if dem_files:
-            add_provided_dems(
-                dem_files=dem_files,
-                output_dir=config.proc_dir.raw_dems_dir,
-                references_data=config.references_data_mapping,
-                overwrite=config.overwrite,
-            )
+        dems_symlink_dir = config.proc_dir.symlinks_dir / "dems"
+        if dems_symlink_dir.exists():
+            dem_files = list(dems_symlink_dir.glob("*.tif"))
+            if dem_files:
+                add_provided_dems(
+                    dem_files=dem_files,
+                    output_dir=config.proc_dir.raw_dems_dir,
+                    references_data=config.references_data_mapping,
+                    overwrite=config.overwrite,
+                )
+
+    logger.info(f"point2dem log saved at {log_path}")
 
     if not config.no_plots:
         plot_point2dem(config)

--- a/src/history/postprocessing/cli.py
+++ b/src/history/postprocessing/cli.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 _TEMPLATE_CONFIG = Path(__file__).parent / "config.exemple.toml"
 
-RUN_STEPS = ["uncompress", "symlinks", "point2dem", "coregister", "ddem", "std_dem", "landcover", "all"]
+RUN_STEPS = ["uncompress", "symlinks", "check_planned", "point2dem", "coregister", "ddem", "std_dem", "landcover", "all"]
 
 
 def _configure_logging(verbosity: int) -> None:
@@ -112,6 +112,20 @@ def _run_symlinks(config: Config) -> None:
 
     if not config.no_plots:
         plot_symlinks(config.proc_dir.symlinks_dir, config.plot_dir)
+
+
+def _run_check_planned(config: Config) -> None:
+    """Check extracted results against planned submissions sheet."""
+    from history.postprocessing.pipeline import check_planned_submissions
+
+    dense_pc_dir = config.proc_dir.symlinks_dir / "dense_pointclouds"
+    pointcloud_files = list(dense_pc_dir.glob("*.las")) + list(dense_pc_dir.glob("*.laz"))
+    planned_outfile = str(config.proc_dir.base_dir / "planned_submissions.csv")
+    
+    check_planned_submissions(
+        pointcloud_files,
+        planned_outfile,
+    )
 
 
 def _run_point2dem(config: Config) -> None:
@@ -223,6 +237,7 @@ def _run_landcover(config: Config) -> None:
 _STEP_RUNNERS = {
     "uncompress": _run_uncompress,
     "symlinks": _run_symlinks,
+    "check_planned": _run_check_planned,
     "point2dem": _run_point2dem,
     "coregister": _run_coregister,
     "ddem": _run_ddem,

--- a/src/history/postprocessing/cli.py
+++ b/src/history/postprocessing/cli.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 _TEMPLATE_CONFIG = Path(__file__).parent / "config.exemple.toml"
 
-RUN_STEPS = ["uncompress", "symlinks", "check_planned", "point2dem", "coregister", "ddem", "std_dem", "landcover", "all"]
+RUN_STEPS = ["uncompress", "symlinks", "check_planned", "point2dem", "coregister", "ddem", "std_dem", "landcover", "generate_pdf", "all"]
 
 
 def _configure_logging(verbosity: int) -> None:
@@ -110,7 +110,7 @@ def _run_symlinks(config: Config) -> None:
     create_symlinks(df, config.proc_dir.symlinks_dir, overwrite=config.overwrite)
 
     if not config.no_plots:
-        plot_symlinks(config.proc_dir.symlinks_dir, config.plot_dir)
+        plot_symlinks(config)
 
 
 def _run_check_planned(config: Config) -> None:
@@ -152,7 +152,7 @@ def _run_point2dem(config: Config) -> None:
             )
 
     if not config.no_plots:
-        plot_point2dem(config.proc_dir.raw_dems_dir, config.plot_dir, config.max_workers)
+        plot_point2dem(config)
 
 
 def _run_coregister(config: Config) -> None:
@@ -168,7 +168,7 @@ def _run_coregister(config: Config) -> None:
     )
 
     if not config.no_plots:
-        plot_coregistration(config.proc_dir.coreg_dems_dir, config.plot_dir, config.max_workers)
+        plot_coregistration(config)
 
 
 def _run_ddem(config: Config) -> None:
@@ -192,13 +192,7 @@ def _run_ddem(config: Config) -> None:
     )
 
     if not config.no_plots:
-        plot_ddems(
-            config.proc_dir.before_coreg_ddems_dir,
-            config.proc_dir.after_coreg_ddems_dir,
-            config.plot_dir,
-            overwrite=config.overwrite,
-            max_workers=config.max_workers,
-        )
+        plot_ddems(config)
 
 
 def _run_std_dem(config: Config) -> None:
@@ -212,7 +206,7 @@ def _run_std_dem(config: Config) -> None:
     )
 
     if not config.no_plots:
-        plot_std_dems(config.proc_dir.std_dems_dir, config.plot_dir)
+        plot_std_dems(config)
 
 
 def _run_landcover(config: Config) -> None:
@@ -220,13 +214,19 @@ def _run_landcover(config: Config) -> None:
     from history.postprocessing.pipeline import plot_landcover
 
     if not config.no_plots:
-        plot_landcover(
-            config.proc_dir.after_coreg_ddems_dir,
-            config.proc_dir.std_dems_dir,
-            config.references_data_mapping,
-            config.plot_dir,
-            config.max_workers,
-        )
+        plot_landcover(config)
+
+
+def _run_generate_pdf(config: Config) -> None:
+    """Assemble all pipeline output PNGs into a single PDF report."""
+    from history.postprocessing.pdf_report import generate_pdf_report
+
+    generate_pdf_report(
+        extracted_dir=config.extracted_dir,
+        plot_dir=config.plot_dir,
+        filename_renames=config.filename_renames,
+        orientation=config.pdf_orientation,
+    )
 
 
 _STEP_RUNNERS = {
@@ -238,6 +238,7 @@ _STEP_RUNNERS = {
     "ddem": _run_ddem,
     "std_dem": _run_std_dem,
     "landcover": _run_landcover,
+    "generate_pdf": _run_generate_pdf,
 }
 
 

--- a/src/history/postprocessing/cli.py
+++ b/src/history/postprocessing/cli.py
@@ -71,6 +71,9 @@ def _configure_logging(verbosity: int) -> None:
 
     logging.getLogger("history").setLevel(level)
 
+    # Always print high level info for CLI steps (start, finish), regardless of verbose option.
+    logging.getLogger("history.postprocessing.cli").setLevel(logging.INFO)
+
 
 def _load_config(args: argparse.Namespace) -> Config:
     """Load ``Config`` from the TOML file and apply any CLI flag overrides."""
@@ -130,7 +133,7 @@ def _run_symlinks(config: Config) -> None:
 
     df = io.scan_submissions(config.extracted_dir, filename_renames=config.filename_renames)
     io.validate_submissions(df)
-    create_symlinks(df, config.proc_dir.symlinks_dir, overwrite=config.overwrite)
+    create_symlinks(df, config.proc_dir.symlinks_dir, overwrite=True)  # force overwriting the symlinks to avoid issues
     report_symlinks(config)
 
     if not config.no_plots:
@@ -246,6 +249,7 @@ def _run_landcover(config: Config) -> None:
     if not config.no_plots:
         plot_landcover(config)
 
+    logger.info("Step `landcover` finished")
 
 def _run_generate_pdf(config: Config) -> None:
     """Assemble all pipeline output PNGs into a single PDF report."""
@@ -288,6 +292,8 @@ def cmd_run(args: argparse.Namespace) -> None:
         for name, runner in _STEP_RUNNERS.items():
             logger.info(f"Running step: {name}")
             runner(config)
+            logger.info(f"Step `{name}` finished")
+
     else:
         _STEP_RUNNERS[step](config)
 

--- a/src/history/postprocessing/cli.py
+++ b/src/history/postprocessing/cli.py
@@ -181,6 +181,7 @@ def _run_point2dem(config: Config) -> None:
     logger.info(f"point2dem log saved at {log_path}")
 
     if not config.no_plots:
+        logger.info("Plotting raw DEMs mosaics")
         plot_point2dem(config)
 
 

--- a/src/history/postprocessing/cli.py
+++ b/src/history/postprocessing/cli.py
@@ -105,7 +105,7 @@ def _run_symlinks(config: Config) -> None:
     from history.postprocessing import io
     from history.postprocessing.pipeline import create_symlinks, plot_symlinks
 
-    df = io.scan_submissions(config.extracted_dir)
+    df = io.scan_submissions(config.extracted_dir, filename_renames=config.filename_renames)
     io.validate_submissions(df)
     create_symlinks(df, config.proc_dir.symlinks_dir, overwrite=config.overwrite)
 
@@ -118,7 +118,7 @@ def _run_check_planned(config: Config) -> None:
     from history.postprocessing import io
     from history.postprocessing.pipeline import check_planned_submissions
 
-    df = io.scan_submissions(config.extracted_dir)
+    df = io.scan_submissions(config.extracted_dir, filename_renames=config.filename_renames)
     planned_outfile = config.proc_dir.base_dir / "planned_submissions.csv"
     check_planned_submissions(df.index.tolist(), planned_outfile)
 

--- a/src/history/postprocessing/cli.py
+++ b/src/history/postprocessing/cli.py
@@ -102,13 +102,12 @@ def _run_uncompress(config: Config) -> None:
 
 def _run_symlinks(config: Config) -> None:
     """Index submissions, parse filenames, and create typed symlink directories."""
-    from history.postprocessing.pipeline import index_submissions_and_link_files, plot_symlinks
+    from history.postprocessing import io
+    from history.postprocessing.pipeline import create_symlinks, plot_symlinks
 
-    index_submissions_and_link_files(
-        config.extracted_dir,
-        config.proc_dir.symlinks_dir,
-        overwrite=config.overwrite,
-    )
+    df = io.scan_submissions(config.extracted_dir)
+    io.validate_submissions(df)
+    create_symlinks(df, config.proc_dir.symlinks_dir, overwrite=config.overwrite)
 
     if not config.no_plots:
         plot_symlinks(config.proc_dir.symlinks_dir, config.plot_dir)
@@ -116,16 +115,12 @@ def _run_symlinks(config: Config) -> None:
 
 def _run_check_planned(config: Config) -> None:
     """Check extracted results against planned submissions sheet."""
+    from history.postprocessing import io
     from history.postprocessing.pipeline import check_planned_submissions
 
-    dense_pc_dir = config.proc_dir.symlinks_dir / "dense_pointclouds"
-    pointcloud_files = list(dense_pc_dir.glob("*.las")) + list(dense_pc_dir.glob("*.laz"))
-    planned_outfile = str(config.proc_dir.base_dir / "planned_submissions.csv")
-    
-    check_planned_submissions(
-        pointcloud_files,
-        planned_outfile,
-    )
+    df = io.scan_submissions(config.extracted_dir)
+    planned_outfile = config.proc_dir.base_dir / "planned_submissions.csv"
+    check_planned_submissions(df.index.tolist(), planned_outfile)
 
 
 def _run_point2dem(config: Config) -> None:

--- a/src/history/postprocessing/cli.py
+++ b/src/history/postprocessing/cli.py
@@ -226,6 +226,7 @@ def _run_ddem(config: Config) -> None:
     )
 
     if not config.no_plots:
+        logger.info("Plotting dDEMs mosaics")
         plot_ddems(config)
 
 

--- a/src/history/postprocessing/cli.py
+++ b/src/history/postprocessing/cli.py
@@ -110,7 +110,7 @@ def _run_symlinks(config: Config) -> None:
     create_symlinks(df, config.proc_dir.symlinks_dir, overwrite=config.overwrite)
 
     if not config.no_plots:
-        plot_symlinks(config)
+        plot_symlinks(config, submissions_df=df)
 
 
 def _run_check_planned(config: Config) -> None:

--- a/src/history/postprocessing/config.exemple.toml
+++ b/src/history/postprocessing/config.exemple.toml
@@ -7,6 +7,7 @@ overwrite = false
 dry_run = false
 pdal_exec_path = "pdal"
 max_workers = 4
+pdf_orientation = "auto"
 
 [references_data_mapping.casa_grande.aerial]
 ref_dem = "/path/to/casa_grande/aerial/ref_dem.tif"

--- a/src/history/postprocessing/config.exemple.toml
+++ b/src/history/postprocessing/config.exemple.toml
@@ -1,4 +1,11 @@
 raw_dir = "/path/to/raw"
+
+# Optional: correct mis-named submission files without touching the files on disk.
+# Keys are the bad file stem (without extension), values are the corrected stems.
+# One entry per mis-named file (e.g. one for _dense_pointcloud, one for _extrinsics, …).
+# [filename_renames]
+# "ALICE_cg_AI_RA_CY_GN_PN_MN_dense_pointcloud" = "ALICE_CG_AI_RA_CY_GN_PN_MN_dense_pointcloud"
+# "ALICE_cg_AI_RA_CY_GN_PN_MN_sparse_pointcloud" = "ALICE_CG_AI_RA_CY_GN_PN_MN_sparse_pointcloud"
 extracted_dir = "/path/to/extracted"
 proc_dir = "/path/to/processing"
 plot_dir = "/path/to/plots"

--- a/src/history/postprocessing/config.exemple.toml
+++ b/src/history/postprocessing/config.exemple.toml
@@ -1,11 +1,4 @@
 raw_dir = "/path/to/raw"
-
-# Optional: correct mis-named submission files without touching the files on disk.
-# Keys are the bad file stem (without extension), values are the corrected stems.
-# One entry per mis-named file (e.g. one for _dense_pointcloud, one for _extrinsics, …).
-# [filename_renames]
-# "ALICE_cg_AI_RA_CY_GN_PN_MN_dense_pointcloud" = "ALICE_CG_AI_RA_CY_GN_PN_MN_dense_pointcloud"
-# "ALICE_cg_AI_RA_CY_GN_PN_MN_sparse_pointcloud" = "ALICE_CG_AI_RA_CY_GN_PN_MN_sparse_pointcloud"
 extracted_dir = "/path/to/extracted"
 proc_dir = "/path/to/processing"
 plot_dir = "/path/to/plots"
@@ -44,3 +37,10 @@ landcover = "/path/to/iceland/kh9mc/landcover.tif"
 ref_dem = "/path/to/iceland/kh9pc/ref_dem.tif"
 ref_dem_mask = "/path/to/iceland/kh9pc/ref_dem_mask.tif"
 landcover = "/path/to/iceland/kh9pc/landcover.tif"
+
+# Optional: correct mis-named submission files without touching the files on disk.
+# Keys are Python re.sub patterns, values are replacement strings (use \1, \2 for groups).
+# Patterns are tried in order; the first match wins. Actual files on disk are never modified.
+# [filename_renames]
+# '(.+_extrinsics)\.txt$' = '\1.csv'          # fix wrong extension
+# '(.+)_tie\.laz$' = '\1_sparse_pointcloud.laz'  # fix wrong suffix

--- a/src/history/postprocessing/config.exemple.toml
+++ b/src/history/postprocessing/config.exemple.toml
@@ -4,6 +4,7 @@ proc_dir = "/path/to/processing"
 plot_dir = "/path/to/plots"
 
 overwrite = false
+overwrite_plots = false
 dry_run = false
 pdal_exec_path = "pdal"
 max_workers = 4

--- a/src/history/postprocessing/config.py
+++ b/src/history/postprocessing/config.py
@@ -78,7 +78,9 @@ class Config:
         Reference DEMs, masks, and landcover rasters for every
         (site, dataset) combination.
     overwrite : bool
-        If True, existing outputs are recomputed. Default False.
+        If True, existing data outputs are recomputed. Default False.
+    overwrite_plots : bool
+        If True, existing plots are regenerated. Default False.
     dry_run : bool
         If True, PDAL commands are prepared but not executed. Default False.
     no_plots : bool
@@ -97,6 +99,7 @@ class Config:
     references_data_mapping: ReferencesData
 
     overwrite: bool = False
+    overwrite_plots: bool = False
     dry_run: bool = False
     no_plots: bool = False
     pdal_exec_path: str = "pdal"
@@ -136,6 +139,7 @@ class Config:
             plot_dir=Path(data["plot_dir"]),
             references_data_mapping=ReferencesData(references_data_mapping),
             overwrite=data.get("overwrite", False),
+            overwrite_plots=data.get("overwrite_plots", False),
             dry_run=data.get("dry_run", False),
             pdal_exec_path=data.get("pdal_exec_path", "pdal"),
             max_workers=data.get("max_workers", 4),

--- a/src/history/postprocessing/config.py
+++ b/src/history/postprocessing/config.py
@@ -102,6 +102,7 @@ class Config:
     pdal_exec_path: str = "pdal"
     max_workers: int = 4
     filename_renames: dict[str, str] | None = None
+    pdf_orientation: str = "auto"
 
     @classmethod
     def from_toml_file(cls, path: Path) -> "Config":

--- a/src/history/postprocessing/config.py
+++ b/src/history/postprocessing/config.py
@@ -101,6 +101,7 @@ class Config:
     no_plots: bool = False
     pdal_exec_path: str = "pdal"
     max_workers: int = 4
+    filename_renames: dict[str, str] | None = None
 
     @classmethod
     def from_toml_file(cls, path: Path) -> "Config":
@@ -137,6 +138,7 @@ class Config:
             dry_run=data.get("dry_run", False),
             pdal_exec_path=data.get("pdal_exec_path", "pdal"),
             max_workers=data.get("max_workers", 4),
+            filename_renames=data.get("filename_renames") or None,
         )
 
 

--- a/src/history/postprocessing/io.py
+++ b/src/history/postprocessing/io.py
@@ -892,7 +892,12 @@ def scan_submissions(input_dir: str | Path) -> pd.DataFrame:
             row = rows.setdefault(code, {"submission": subdir.name, **metadata})
             for col, pattern in _ALL_FILE_PATTERNS.items():
                 if re.search(pattern, file.name, re.IGNORECASE):
-                    row[col] = str(file)
+                    if col in row:
+                        logger.warning(
+                            f"{code}: duplicate {col} — keeping '{row[col]}', ignoring '{file}'"
+                        )
+                    else:
+                        row[col] = str(file)
                     break
 
     df = pd.DataFrame.from_dict(rows, orient="index")

--- a/src/history/postprocessing/io.py
+++ b/src/history/postprocessing/io.py
@@ -12,22 +12,22 @@ FILE_CODE_MAPPING: dict[str, dict[str, str]] = {
     "site": {"CG": "casa_grande", "IL": "iceland"},
     "dataset": {"AI": "aerial", "MC": "kh9mc", "PC": "kh9pc"},
     "images": {"RA": "raw", "PP": "preprocessed"},
-    "camera_used": {"CY": "Yes", "CN": "No"},
-    "gcp_used": {"GM": "Manual (provided)", "GA": "Automated approach", "GN": "No", "GY": "Yes"},
+    "calib_used": {"CY": "Yes", "CN": "No"},
+    "georef": {"GM": "Manual (provided)", "GA": "Automated approach", "GC": "Coregistration", "GN": "No/other"},
     "pointcloud_coregistration": {"PY": "Yes", "PN": "No"},
-    "mtp_adjustment": {"MY": "Yes", "MN": "No"},
+    "mtp_adjustments": {"MY": "Yes", "MN": "No"},
 }
 
 FILENAME_PATTERN = re.compile(
     r"""
-    ^(?P<author>[^_]+)_
+    ^(?P<author>[A-Za-z0-9]{3,6})_
     (?P<site>[A-Z]{2})_
     (?P<dataset>[A-Z]{2})_
     (?P<images>[A-Z]{2})_
-    (?P<camera_used>[A-Z]{2})_
-    (?P<gcp_used>[A-Z]{2})_
+    (?P<calib_used>[A-Z]{2})_
+    (?P<georef>[A-Z]{2})_
     (?P<pointcloud_coregistration>[A-Z]{2})_
-    (?P<mtp_adjustment>[A-Z]{2})
+    (?P<mtp_adjustments>[A-Z]{2})
     (?:_(?P<version>V\d+))?
     .*$
     """,
@@ -759,13 +759,13 @@ def mirror_as_symlinks(src_dir: str | Path, dst_dir: str | Path, overwrite: bool
 
 def parse_filename(file: str | Path) -> tuple[str, dict[str, Any]]:
     """
-    Parse a filename following the predefined code convention described in FILE_CODE_MAPPING_V1.
+    Parse a filename following the predefined code convention described in FILE_CODE_MAPPING.
 
     This function extracts structured information from a filename built using a specific
     naming convention such as:
         AUTHOR_SITE_DATASET_IMAGES_CAMERAUSED_GCPUSED_POINTCLOUDCOREG_MTPADJ[_V1-DEM].tif
 
-    Each short code (e.g., 'CG', 'AI', 'RA', 'CY') is validated against FILE_CODE_MAPPING_V1
+    Each short code (e.g., 'CG', 'AI', 'RA', 'CY') is validated against FILE_CODE_MAPPING
     to ensure consistency and then mapped to its corresponding descriptive value.
 
     Args:
@@ -778,7 +778,7 @@ def parse_filename(file: str | Path) -> tuple[str, dict[str, Any]]:
 
     Raises:
         ValueError: If the filename does not respect the expected naming convention
-                    or contains unknown codes not defined in FILE_CODE_MAPPING_V1.
+                    or contains unknown codes not defined in FILE_CODE_MAPPING.
     """
     match = FILENAME_PATTERN.match(Path(file).stem)
 

--- a/src/history/postprocessing/io.py
+++ b/src/history/postprocessing/io.py
@@ -809,7 +809,7 @@ def parse_filename(file: str | Path) -> tuple[str, dict[str, Any]]:
         ValueError: If the filename does not respect the expected naming convention
                     or contains unknown codes not defined in FILE_CODE_MAPPING.
     """
-    stem = Path(file).stem
+    stem = Path(file).stem.split("-")[0]  # strip file-type suffix (e.g. -DEM, -orthoimage)
     parts = stem.split("_")
 
     raw: dict[str, str | None] = {}

--- a/src/history/postprocessing/io.py
+++ b/src/history/postprocessing/io.py
@@ -833,6 +833,94 @@ def parse_filename(file: str | Path) -> tuple[str, dict[str, Any]]:
     return code, metadatas
 
 
+# Regex patterns for recognising submission file types, keyed by DataFrame column name.
+_MANDATORY_FILE_PATTERNS: dict[str, str] = {
+    "dense_pointcloud_file": r"_dense_pointcloud\.(las|laz)$",
+    "sparse_pointcloud_file": r"_sparse_pointcloud\.(las|laz)$",
+    "extrinsics_file": r"_extrinsics\.csv$",
+    "intrinsics_file": r"_intrinsics\.csv$",
+}
+_OPTIONAL_FILE_PATTERNS: dict[str, str] = {
+    "dem_file": r".*dem.*\.tif$",
+    "orthoimage_file": r".*orthoimage.*\.tif$",
+}
+_ALL_FILE_PATTERNS: dict[str, str] = {**_MANDATORY_FILE_PATTERNS, **_OPTIONAL_FILE_PATTERNS}
+
+# Maps DataFrame column names to their symlink subdirectory names.
+_FILE_COL_TO_SUBDIR: dict[str, str] = {
+    "dense_pointcloud_file": "dense_pointclouds",
+    "sparse_pointcloud_file": "sparse_pointclouds",
+    "extrinsics_file": "extrinsics",
+    "intrinsics_file": "intrinsics",
+    "dem_file": "dems",
+    "orthoimage_file": "orthoimages",
+}
+
+
+def scan_submissions(input_dir: str | Path) -> pd.DataFrame:
+    """Scan submission subdirectories and return a DataFrame indexed by submission code.
+
+    Each row represents one submission with columns for parsed metadata fields and file
+    paths (one per recognised file type). Parse errors on relevant extensions (.las,
+    .laz, .tif, .csv) are logged as warnings; all other extensions are logged at DEBUG.
+    If the same code appears in multiple submission folders, the first folder wins and a
+    warning is emitted.
+    """
+    input_dir = Path(input_dir)
+    _relevant_extensions = {".las", ".laz", ".tif", ".csv"}
+    rows: dict[str, dict] = {}
+
+    for subdir in sorted(input_dir.iterdir()):
+        if not subdir.is_dir():
+            continue
+        for file in subdir.rglob("*"):
+            try:
+                code, metadata = parse_filename(file)
+            except FilenameParseError as e:
+                if file.suffix.lower() in _relevant_extensions:
+                    logger.warning(f"Cannot parse filename: {e}")
+                else:
+                    logger.debug(f"Skipping non-submission file: {e}")
+                continue
+
+            if code in rows and rows[code]["submission"] != subdir.name:
+                logger.warning(
+                    f"{code}: found in multiple submission folders, keeping '{rows[code]['submission']}'"
+                )
+                continue
+
+            row = rows.setdefault(code, {"submission": subdir.name, **metadata})
+            for col, pattern in _ALL_FILE_PATTERNS.items():
+                if re.search(pattern, file.name, re.IGNORECASE):
+                    row[col] = str(file)
+                    break
+
+    df = pd.DataFrame.from_dict(rows, orient="index")
+    df.index.name = "code"
+    return df
+
+
+def validate_submissions(df: pd.DataFrame) -> None:
+    """Log a validation summary of mandatory file completeness across all submissions.
+
+    Logs an INFO message when all submissions are complete, or a WARNING summary
+    listing each submission with missing mandatory files.
+    """
+    issues: dict[str, list[str]] = {}
+    for code, row in df.iterrows():
+        missing = [col for col in _MANDATORY_FILE_PATTERNS if pd.isna(row.get(col))]
+        if missing:
+            issues[code] = missing
+
+    if not issues:
+        logger.info(f"All {len(df)} submissions are complete.")
+        return
+
+    logger.warning(f"{len(issues)}/{len(df)} submissions have missing mandatory files:")
+    for code, missing in sorted(issues.items()):
+        logger.warning(f"  {code}: missing {missing}")
+
+
 class ReferencesData:
     def __init__(self, references_data_mapping: dict[tuple[str, str], dict[str, str | Path]]):
         """

--- a/src/history/postprocessing/io.py
+++ b/src/history/postprocessing/io.py
@@ -23,21 +23,45 @@ FILE_CODE_MAPPING: dict[str, dict[str, str]] = {
     "mtp_adjustments": {"MY": "Yes", "MN": "No"},
 }
 
-FILENAME_PATTERN = re.compile(
-    r"""
-    ^(?P<author>[A-Za-z0-9]{3,6})_
-    (?P<site>CG|IL)_
-    (?P<dataset>AI|MC|PC)_
-    (?P<images>PP|RA)_
-    (?P<calib_used>C[YN])_
-    (?P<georef>G[MACN])_
-    (?P<pointcloud_coregistration>P[YN])_
-    (?P<mtp_adjustments>M[YN])
-    (?:_(?P<version>V\d+))?
-    .*$
-    """,
-    re.VERBOSE | re.IGNORECASE,
-)
+# Per-segment patterns — used for both parsing and error diagnosis.
+_SEGMENT_PATTERNS: list[tuple[str, re.Pattern]] = [
+    ("author", re.compile(r"^[A-Za-z0-9]{3,6}$")),
+    ("site", re.compile(r"^(CG|IL)$", re.IGNORECASE)),
+    ("dataset", re.compile(r"^(AI|MC|PC)$", re.IGNORECASE)),
+    ("images", re.compile(r"^(PP|RA)$", re.IGNORECASE)),
+    ("calib_used", re.compile(r"^C[YN]$", re.IGNORECASE)),
+    ("georef", re.compile(r"^G[MACN]$", re.IGNORECASE)),
+    ("pointcloud_coregistration", re.compile(r"^P[YN]$", re.IGNORECASE)),
+    ("mtp_adjustments", re.compile(r"^M[YN]$", re.IGNORECASE)),
+]
+
+_VERSION_PATTERN = re.compile(r"^V\d+$", re.IGNORECASE)
+
+
+class FilenameParseError(ValueError):
+    """Raised when a filename does not conform to the submission naming convention.
+
+    Attributes
+    ----------
+    stem : str
+        The filename stem that failed to parse.
+    segment : str or None
+        Name of the first segment that caused the failure, if identifiable.
+    got : str or None
+        The actual value found in the failing segment.
+    """
+
+    def __init__(self, stem: str, reason: str, segment: str | None = None, got: str | None = None):
+        self.stem = stem
+        self.segment = segment
+        self.got = got
+        msg = f"'{stem}': {reason}"
+        if segment and got is not None:
+            expected = list(FILE_CODE_MAPPING[segment]) if segment in FILE_CODE_MAPPING else None
+            msg += f" — segment '{segment}': got '{got}'"
+            if expected:
+                msg += f", expected one of {expected}"
+        super().__init__(msg)
 
 
 def check_disk_space_and_estimate(archive_files: List[Path], output_dir: Path) -> Dict[str, float]:
@@ -785,21 +809,27 @@ def parse_filename(file: str | Path) -> tuple[str, dict[str, Any]]:
         ValueError: If the filename does not respect the expected naming convention
                     or contains unknown codes not defined in FILE_CODE_MAPPING.
     """
-    match = FILENAME_PATTERN.match(Path(file).stem)
+    stem = Path(file).stem
+    parts = stem.split("_")
 
-    if not match:
-        raise ValueError(f"The filename {Path(file).stem} does not respect the code convention")
+    raw: dict[str, str | None] = {}
+    for i, (seg_name, seg_pattern) in enumerate(_SEGMENT_PATTERNS):
+        if i >= len(parts):
+            raise FilenameParseError(stem, f"filename too short, missing segment '{seg_name}'", seg_name, None)
+        if not seg_pattern.match(parts[i]):
+            raise FilenameParseError(stem, "invalid segment value", seg_name, parts[i])
+        raw[seg_name] = parts[i]
 
-    match_dict = match.groupdict()
-    metadatas = {"author": match_dict["author"]}
+    version_idx = len(_SEGMENT_PATTERNS)
+    raw["version"] = parts[version_idx] if version_idx < len(parts) and _VERSION_PATTERN.match(parts[version_idx]) else None
 
-    for key, value in match_dict.items():
-        if key in FILE_CODE_MAPPING:
+    metadatas: dict[str, Any] = {"author": raw["author"]}
+    for key, value in raw.items():
+        if key in FILE_CODE_MAPPING and value is not None:
             metadatas[key] = FILE_CODE_MAPPING[key].get(value)
+    metadatas["version"] = raw["version"]
 
-    metadatas["version"] = match_dict.get("version")
-
-    code = "_".join([v for v in match_dict.values() if v is not None])
+    code = "_".join(v for v in raw.values() if v is not None)
     return code, metadatas
 
 

--- a/src/history/postprocessing/io.py
+++ b/src/history/postprocessing/io.py
@@ -858,15 +858,19 @@ _FILE_COL_TO_SUBDIR: dict[str, str] = {
 
 
 def _apply_filename_rename(filename: str, filename_renames: dict[str, str] | None) -> str:
-    """Return *filename* with its stem replaced if it appears in *filename_renames*."""
+    """Return *filename* renamed according to *filename_renames*.
+
+    Keys are Python ``re.sub`` patterns; values are replacement strings. Patterns are
+    tried in insertion order and the first match wins.
+    Example: ``{r'(.+_extrinsics)\\.txt$': r'\\1.csv'}``
+    """
     if not filename_renames:
         return filename
-    ext = Path(filename).suffix
-    bare_stem = Path(filename).stem
-    if bare_stem in filename_renames:
-        new_stem = filename_renames[bare_stem]
-        logger.debug(f"Applying filename rename: '{bare_stem}' → '{new_stem}'")
-        return new_stem + ext
+    for pattern, replacement in filename_renames.items():
+        new_filename, n = re.subn(pattern, replacement, filename)
+        if n > 0:
+            logger.debug(f"Applying filename rename: '{filename}' → '{new_filename}' (pattern: {pattern!r})")
+            return new_filename
     return filename
 
 
@@ -884,11 +888,11 @@ def scan_submissions(input_dir: str | Path, filename_renames: dict[str, str] | N
     input_dir:
         Directory containing one subdirectory per submission.
     filename_renames:
-        Optional mapping from bad file stems (without extension) to corrected stems.
-        Applied before parsing, so that mis-named files are treated as if they had the
-        corrected name. The actual files on disk are never modified.
-        Example: ``{"ALICE_cg_AI_RA_CY_GN_PN_MN_dense_pointcloud":
-                     "ALICE_CG_AI_RA_CY_GN_PN_MN_dense_pointcloud"}``
+        Optional mapping of Python ``re.sub`` patterns to replacement strings. Applied
+        before parsing; actual files on disk are never modified. Patterns are tried in
+        insertion order; the first match wins.
+        Example: ``{r'(.+_extrinsics)\\.txt$': r'\\1.csv',
+                     r'(.+)_tie\\.laz$': r'\\1_sparse_pointcloud.laz'}``
     """
     input_dir = Path(input_dir)
     _relevant_extensions = {".las", ".laz", ".tif", ".csv"}
@@ -897,6 +901,7 @@ def scan_submissions(input_dir: str | Path, filename_renames: dict[str, str] | N
     for subdir in sorted(input_dir.iterdir()):
         if not subdir.is_dir():
             continue
+        logger.debug(f"Scanning {subdir.name}...")
         for file in subdir.rglob("*"):
             virtual_name = _apply_filename_rename(file.name, filename_renames)
             try:
@@ -916,15 +921,17 @@ def scan_submissions(input_dir: str | Path, filename_renames: dict[str, str] | N
 
             row = rows.setdefault(code, {"submission": subdir.name, **metadata})
             for col, pattern in _ALL_FILE_PATTERNS.items():
-                if re.search(pattern, file.name, re.IGNORECASE):
+                if re.search(pattern, virtual_name, re.IGNORECASE):
                     if col in row:
                         logger.warning(
                             f"{code}: duplicate {col} — keeping '{row[col]}', ignoring '{file}'"
                         )
                     else:
                         row[col] = str(file)
+                        row[col.removesuffix("_file") + "_name"] = virtual_name
                     break
-
+    
+    logger.info(f"scan_submissions: found {len(rows)} submissions in {input_dir}")
     df = pd.DataFrame.from_dict(rows, orient="index")
     df.index.name = "code"
     return df

--- a/src/history/postprocessing/io.py
+++ b/src/history/postprocessing/io.py
@@ -3,7 +3,7 @@ import shutil
 import tarfile
 import zipfile
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Union
+from typing import Any, Dict, Iterable, List, Sequence, Union
 import logging
 
 import pandas as pd
@@ -1071,3 +1071,30 @@ def download_planned_submissions(outfile: str | Path) -> None:
     logger.info(f"Saved CSV to file {outfile}.")
 
     return submissions_df
+
+
+def is_output_up_to_date(inputs: str | Path | Sequence[str | Path], outputs: str | Path | Sequence[str | Path]) -> bool:
+    """Return True if all outputs exist and are newer than all inputs."""
+    inputs = [inputs] if isinstance(inputs, (str, Path)) else inputs
+    outputs = [outputs] if isinstance(outputs, (str, Path)) else outputs
+
+    # standardize path
+    inputs = [Path(f) for f in inputs]
+    outputs = [Path(f) for f in outputs]
+
+    if not inputs:
+        raise ValueError("inputs cannot be empty")
+    if not outputs:
+        raise ValueError("outputs cannot be empty")
+
+    if any(not p.exists() for p in outputs):
+        return False
+
+    for p in inputs:
+        if not p.exists():
+            raise FileNotFoundError(f"Input file not found: {p}")
+
+    oldest_output = min(p.stat().st_mtime for p in outputs)
+    newest_input = max(p.stat().st_mtime for p in inputs)
+
+    return newest_input <= oldest_output

--- a/src/history/postprocessing/io.py
+++ b/src/history/postprocessing/io.py
@@ -4,9 +4,14 @@ import tarfile
 import zipfile
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Union
+import logging
 
 import pandas as pd
 import py7zr
+import gdown
+
+logger = logging.getLogger(__name__)
+
 
 FILE_CODE_MAPPING: dict[str, dict[str, str]] = {
     "site": {"CG": "casa_grande", "IL": "iceland"},
@@ -21,13 +26,13 @@ FILE_CODE_MAPPING: dict[str, dict[str, str]] = {
 FILENAME_PATTERN = re.compile(
     r"""
     ^(?P<author>[A-Za-z0-9]{3,6})_
-    (?P<site>[A-Z]{2})_
-    (?P<dataset>[A-Z]{2})_
-    (?P<images>[A-Z]{2})_
-    (?P<calib_used>[A-Z]{2})_
-    (?P<georef>[A-Z]{2})_
-    (?P<pointcloud_coregistration>[A-Z]{2})_
-    (?P<mtp_adjustments>[A-Z]{2})
+    (?P<site>CG|IL)_
+    (?P<dataset>AI|MC|PC)_
+    (?P<images>PP|RA)_
+    (?P<calib_used>C[YN])_
+    (?P<georef>G[MACN])_
+    (?P<pointcloud_coregistration>P[YN])_
+    (?P<mtp_adjustments>M[YN])
     (?:_(?P<version>V\d+))?
     .*$
     """,
@@ -783,7 +788,7 @@ def parse_filename(file: str | Path) -> tuple[str, dict[str, Any]]:
     match = FILENAME_PATTERN.match(Path(file).stem)
 
     if not match:
-        raise ValueError(f"The filename {Path(file).stem} don't respect the code convention")
+        raise ValueError(f"The filename {Path(file).stem} does not respect the code convention")
 
     match_dict = match.groupdict()
     metadatas = {"author": match_dict["author"]}
@@ -886,3 +891,28 @@ def get_filepaths_df(**kwargs: Iterable[str | Path]) -> pd.DataFrame:
             except ValueError:
                 continue
     return df.sort_index()
+
+
+def download_planned_submissions(outfile: str | Path) -> None:
+    """
+    Download the table of planned submissions from the shared Google sheet document.
+    File is downloaded to `outfile` in CSV format and unused rows/columns are deleted.
+    """
+    # Convert POSIX path to str
+    outfile= str(outfile)
+
+    sheet_url="https://docs.google.com/spreadsheets/d/1jGuoQYSfSd-DqbKp_7ZpkTYFIgC47camspTsgqkT_gQ/edit?usp=sharing"
+    verbose=(logger.getEffectiveLevel()<=20)
+    gdown.download(url=sheet_url, output=outfile, format="csv", quiet=(not verbose))
+
+    # Load as DataFrame and filter empty rows and Total row
+    submissions_df = pd.read_csv(outfile, skiprows=2, delimiter=",", usecols=[0, 1, 2, 3, 4])
+    submissions_df = submissions_df[~(submissions_df["Group name"] == "Total") & ~submissions_df["Group name"].isna()]
+
+    # Save to file
+    submissions_df.to_csv(outfile)
+
+    logger.info(f"Found {len(submissions_df)} planned submissions.")
+    logger.info(f"Saved CSV to file {outfile}.")
+
+    return submissions_df

--- a/src/history/postprocessing/io.py
+++ b/src/history/postprocessing/io.py
@@ -857,7 +857,20 @@ _FILE_COL_TO_SUBDIR: dict[str, str] = {
 }
 
 
-def scan_submissions(input_dir: str | Path) -> pd.DataFrame:
+def _apply_filename_rename(filename: str, filename_renames: dict[str, str] | None) -> str:
+    """Return *filename* with its stem replaced if it appears in *filename_renames*."""
+    if not filename_renames:
+        return filename
+    ext = Path(filename).suffix
+    bare_stem = Path(filename).stem
+    if bare_stem in filename_renames:
+        new_stem = filename_renames[bare_stem]
+        logger.debug(f"Applying filename rename: '{bare_stem}' → '{new_stem}'")
+        return new_stem + ext
+    return filename
+
+
+def scan_submissions(input_dir: str | Path, filename_renames: dict[str, str] | None = None) -> pd.DataFrame:
     """Scan submission subdirectories and return a DataFrame indexed by submission code.
 
     Each row represents one submission with columns for parsed metadata fields and file
@@ -865,6 +878,17 @@ def scan_submissions(input_dir: str | Path) -> pd.DataFrame:
     .laz, .tif, .csv) are logged as warnings; all other extensions are logged at DEBUG.
     If the same code appears in multiple submission folders, the first folder wins and a
     warning is emitted.
+
+    Parameters
+    ----------
+    input_dir:
+        Directory containing one subdirectory per submission.
+    filename_renames:
+        Optional mapping from bad file stems (without extension) to corrected stems.
+        Applied before parsing, so that mis-named files are treated as if they had the
+        corrected name. The actual files on disk are never modified.
+        Example: ``{"ALICE_cg_AI_RA_CY_GN_PN_MN_dense_pointcloud":
+                     "ALICE_CG_AI_RA_CY_GN_PN_MN_dense_pointcloud"}``
     """
     input_dir = Path(input_dir)
     _relevant_extensions = {".las", ".laz", ".tif", ".csv"}
@@ -874,8 +898,9 @@ def scan_submissions(input_dir: str | Path) -> pd.DataFrame:
         if not subdir.is_dir():
             continue
         for file in subdir.rglob("*"):
+            virtual_name = _apply_filename_rename(file.name, filename_renames)
             try:
-                code, metadata = parse_filename(file)
+                code, metadata = parse_filename(virtual_name)
             except FilenameParseError as e:
                 if file.suffix.lower() in _relevant_extensions:
                     logger.warning(f"Cannot parse filename: {e}")

--- a/src/history/postprocessing/pdf_report.py
+++ b/src/history/postprocessing/pdf_report.py
@@ -42,6 +42,7 @@ def _add_png_page(
     pdf: PdfPages,
     path: Path,
     orientation: Literal["auto", "portrait", "landscape"] = "auto",
+    dpi: int = 300,
 ) -> None:
     """Insert an existing PNG as a new PDF page; warn and skip if absent.
 
@@ -77,7 +78,7 @@ def _add_png_page(
         ax_w = img_aspect / page_aspect
 
     ax.set_position([(1 - ax_w) / 2, (1 - ax_h) / 2, ax_w, ax_h])
-    pdf.savefig(fig)
+    pdf.savefig(fig, dpi=dpi)
     plt.close(fig)
 
 

--- a/src/history/postprocessing/pdf_report.py
+++ b/src/history/postprocessing/pdf_report.py
@@ -1,0 +1,219 @@
+"""
+Assemble pipeline output PNGs into a single PDF report.
+"""
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+import matplotlib.image as mpimg
+import matplotlib.pyplot as plt
+import pandas as pd
+from matplotlib.backends.backend_pdf import PdfPages
+
+logger = logging.getLogger(__name__)
+
+# All (site, dataset) pairs in display order
+_SITE_DATASET_PAIRS = [
+    ("casa_grande", "aerial"),
+    ("casa_grande", "kh9mc"),
+    ("casa_grande", "kh9pc"),
+    ("iceland", "aerial"),
+    ("iceland", "kh9mc"),
+    ("iceland", "kh9pc"),
+]
+
+_SITE_DISPLAY = {"casa_grande": "Casa Grande", "iceland": "Iceland"}
+_DATASET_DISPLAY = {"aerial": "Aerial", "kh9mc": "KH-9 MC", "kh9pc": "KH-9 PC"}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Low-level helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+# Standard A4 portrait dimensions in inches
+_PAGE_W = 8.27
+_PAGE_H = 11.69
+
+
+def _add_png_page(
+    pdf: PdfPages,
+    path: Path,
+    orientation: Literal["auto", "portrait", "landscape"] = "auto",
+) -> None:
+    """Insert an existing PNG as a new PDF page; warn and skip if absent.
+
+    The image is centred and scaled to fill the available area while preserving
+    its aspect ratio. Page orientation is determined by ``orientation``:
+    ``"portrait"`` and ``"landscape"`` force A4 in that direction; ``"auto"``
+    picks landscape when the image is wider than tall, portrait otherwise.
+    """
+    path = Path(path)
+    if not path.exists():
+        logger.warning(f"Missing figure (skipping): {path}")
+        return
+
+    img = mpimg.imread(str(path))
+    h_px, w_px = img.shape[:2]
+
+    if orientation == "landscape" or (orientation == "auto" and w_px > h_px):
+        page_w, page_h = _PAGE_H, _PAGE_W  # A4 landscape
+    else:
+        page_w, page_h = _PAGE_W, _PAGE_H  # A4 portrait
+
+    fig, ax = plt.subplots(figsize=(page_w, page_h))
+    ax.imshow(img, aspect="equal")
+    ax.axis("off")
+
+    img_aspect = w_px / h_px
+    page_aspect = page_w / page_h
+    if img_aspect > page_aspect:
+        ax_w = 1.0
+        ax_h = page_aspect / img_aspect
+    else:
+        ax_h = 1.0
+        ax_w = img_aspect / page_aspect
+
+    ax.set_position([(1 - ax_w) / 2, (1 - ax_h) / 2, ax_w, ax_h])
+    pdf.savefig(fig)
+    plt.close(fig)
+
+
+def _add_section_title_page(pdf: PdfPages, title: str) -> None:
+    """Add a centred text page as a section separator (A4 portrait)."""
+    fig, ax = plt.subplots(figsize=(_PAGE_W, _PAGE_H))
+    ax.axis("off")
+    ax.text(
+        0.5, 0.5, title,
+        ha="center", va="center",
+        fontsize=28, fontweight="bold",
+        transform=ax.transAxes,
+    )
+    pdf.savefig(fig)
+    plt.close(fig)
+
+
+def _build_summary_page(pdf: PdfPages, df: pd.DataFrame) -> None:
+    """Build the opening summary page: header text + site×dataset submission count table."""
+    n_submissions = len(df)
+    n_authors = df["author"].nunique() if "author" in df.columns else "?"
+
+    # Build count pivot; rename to human-readable labels
+    counts: pd.DataFrame = df.groupby(["site", "dataset"]).size().unstack(fill_value=0)
+    counts.index = [_SITE_DISPLAY.get(s, s) for s in counts.index]
+    counts.columns = [_DATASET_DISPLAY.get(d, d) for d in counts.columns]
+
+    # Ensure every expected column is present (zero if no submissions)
+    for col in _DATASET_DISPLAY.values():
+        if col not in counts.columns:
+            counts[col] = 0
+    counts = counts[[c for c in _DATASET_DISPLAY.values() if c in counts.columns]]
+
+    fig, ax = plt.subplots(figsize=(_PAGE_W, _PAGE_H))
+    ax.axis("off")
+
+    today = datetime.now().strftime("%d %b %Y")
+    ax.text(
+        0.5, 0.88, "Submissions Summary",
+        ha="center", va="top",
+        fontsize=26, fontweight="bold",
+        transform=ax.transAxes,
+    )
+    ax.text(
+        0.5, 0.78,
+        f"As of {today} — {n_submissions} submissions from {n_authors} different authors",
+        ha="center", va="top",
+        fontsize=13, style="italic",
+        transform=ax.transAxes,
+    )
+
+    # Use reset_index so the site name becomes a normal column with controllable width
+    counts_display = counts.reset_index()
+    counts_display.columns = [""] + list(counts.columns)
+
+    table = ax.table(
+        cellText=counts_display.values.tolist(),
+        colLabels=counts_display.columns.tolist(),
+        loc="center",
+        cellLoc="center",
+        bbox=[0.15, 0.52, 0.7, 0.18]
+    )
+    table.auto_set_font_size(False)
+    table.set_fontsize(12)
+
+    pdf.savefig(fig)
+    plt.close(fig)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Public API
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def generate_pdf_report(
+    extracted_dir: Path,
+    plot_dir: Path,
+    filename_renames: dict[str, str] | None = None,
+    output_path: Path | None = None,
+    orientation: Literal["auto", "portrait", "landscape"] = "auto",
+) -> Path:
+    """
+    Assemble all pipeline output PNGs into a single PDF report.
+
+    Parameters
+    ----------
+    extracted_dir :
+        Directory containing extracted submission subdirectories; used to compute
+        the summary statistics shown on the title page.
+    plot_dir :
+        Root of the plot directory produced by the pipeline steps.
+    filename_renames :
+        Optional rename rules forwarded to ``io.scan_submissions``.
+    output_path :
+        Destination path for the PDF. Defaults to ``plot_dir/report.pdf``.
+    orientation :
+        Page orientation for image pages. ``"portrait"`` forces A4 portrait,
+        ``"landscape"`` forces A4 landscape, ``"auto"`` (default) picks
+        landscape when the image is wider than tall and portrait otherwise.
+
+    Returns
+    -------
+    Path
+        Path to the generated PDF file.
+    """
+    from history.postprocessing import io
+
+    plot_dir = Path(plot_dir)
+    output_path = Path(output_path) if output_path else plot_dir / "report.pdf"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    df = io.scan_submissions(extracted_dir, filename_renames=filename_renames)
+
+    with PdfPages(output_path) as pdf:
+
+        # 1. Summary page (generated programmatically from scan_submissions) ──
+        _build_summary_page(pdf, df)
+
+        # 2. Submissions presence map
+        _add_png_page(pdf, plot_dir / "submissions_presence_map.png", orientation)
+
+        # 3. Global plots
+        _add_png_page(pdf, plot_dir / "pointcloud_point_count.png", orientation)
+        _add_png_page(pdf, plot_dir / "nmad_after_coregistration.png", orientation)
+
+        # 4. Per-(site, dataset) sections
+        for site, dataset in _SITE_DATASET_PAIRS:
+            sub_dir = plot_dir / f"{site}_{dataset}"
+            _add_section_title_page(pdf, f"{_SITE_DISPLAY[site]}  —  {_DATASET_DISPLAY[dataset]}")
+
+            _add_png_page(pdf, sub_dir / "mosaic" / "mosaic_raw_dem.png", orientation)
+            _add_png_page(pdf, sub_dir / "mosaic" / "mosaic_ddem.png", orientation)
+            _add_png_page(pdf, sub_dir / "mosaic" / "mosaic_hillshades_ddem.png", orientation)
+            _add_png_page(pdf, sub_dir / "mosaic" / "mosaic_slopes_ddem.png", orientation)
+            _add_png_page(pdf, sub_dir / "nmad_before_vs_after_coregistration.png", orientation)
+            _add_png_page(pdf, sub_dir / "coregistration_shifts.png", orientation)
+
+    logger.info(f"PDF report saved to {output_path}")
+    return output_path

--- a/src/history/postprocessing/pdf_report.py
+++ b/src/history/postprocessing/pdf_report.py
@@ -159,6 +159,7 @@ def generate_pdf_report(
     filename_renames: dict[str, str] | None = None,
     output_path: Path | None = None,
     orientation: Literal["auto", "portrait", "landscape"] = "auto",
+    overwrite: bool = False,
 ) -> Path:
     """
     Assemble all pipeline output PNGs into a single PDF report.
@@ -185,10 +186,17 @@ def generate_pdf_report(
         Path to the generated PDF file.
     """
     from history.postprocessing import io
+    from history.postprocessing.io import is_output_up_to_date
 
     plot_dir = Path(plot_dir)
     output_path = Path(output_path) if output_path else plot_dir / "report.pdf"
     output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not overwrite:
+        png_files = list(plot_dir.rglob("*.png"))
+        if png_files and is_output_up_to_date(png_files, output_path):
+            logger.info(f"PDF report {output_path} is up to date -> skipping.")
+            return output_path
 
     df = io.scan_submissions(extracted_dir, filename_renames=filename_renames)
 

--- a/src/history/postprocessing/pdf_report.py
+++ b/src/history/postprocessing/pdf_report.py
@@ -196,8 +196,9 @@ def generate_pdf_report(
         # 1. Summary page (generated programmatically from scan_submissions) ──
         _build_summary_page(pdf, df)
 
-        # 2. Submissions presence map
+        # 2. Submissions presence map + file sizes
         _add_png_page(pdf, plot_dir / "submissions_presence_map.png", orientation)
+        _add_png_page(pdf, plot_dir / "submissions_file_sizes.png", orientation)
 
         # 3. Global plots
         _add_png_page(pdf, plot_dir / "pointcloud_point_count.png", orientation)

--- a/src/history/postprocessing/pdf_report.py
+++ b/src/history/postprocessing/pdf_report.py
@@ -212,8 +212,8 @@ def generate_pdf_report(
 
             _add_png_page(pdf, sub_dir / "mosaic" / "mosaic_raw_dem.png", orientation)
             _add_png_page(pdf, sub_dir / "mosaic" / "mosaic_ddem.png", orientation)
-            _add_png_page(pdf, sub_dir / "mosaic" / "mosaic_hillshades_ddem.png", orientation)
-            _add_png_page(pdf, sub_dir / "mosaic" / "mosaic_slopes_ddem.png", orientation)
+            _add_png_page(pdf, sub_dir / "mosaic" / "mosaic_hillshades.png", orientation)
+            _add_png_page(pdf, sub_dir / "mosaic" / "mosaic_slopes.png", orientation)
             _add_png_page(pdf, sub_dir / "nmad_before_vs_after_coregistration.png", orientation)
             _add_png_page(pdf, sub_dir / "coregistration_shifts.png", orientation)
 

--- a/src/history/postprocessing/pdf_report.py
+++ b/src/history/postprocessing/pdf_report.py
@@ -198,7 +198,7 @@ def generate_pdf_report(
         _build_summary_page(pdf, df)
 
         # 2. Submissions presence map + file sizes
-        _add_png_page(pdf, plot_dir / "submissions_presence_map.png", orientation)
+        _add_png_page(pdf, plot_dir / "files_presence_map.png", orientation)
         _add_png_page(pdf, plot_dir / "submissions_file_sizes.png", orientation)
 
         # 3. Global plots

--- a/src/history/postprocessing/pipeline.py
+++ b/src/history/postprocessing/pipeline.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Iterable
 
 import geoutils as gu
+from history.postprocessing.config import Config
 import humanize
 import laspy
 import numpy as np
@@ -1061,127 +1062,84 @@ def is_existing_std_dem(dem_files: list[str | Path], output_path: str | Path, me
 #######################################################################################################################
 
 
-def plot_symlinks(symlinks_dir: str | Path, plot_dir: str | Path) -> None:
+def plot_symlinks(config: Config) -> None:
     """
     Generate plots summarizing the indexed symlinks directory.
 
     Computes point-cloud statistics from dense point cloud files and saves
     a bar chart of point counts per submission.
-
-    Parameters
-    ----------
-    symlinks_dir : str or Path
-        Directory containing the symlinked submission files. Must include a
-        ``dense_pointclouds/`` subdirectory.
-    plot_dir : str or Path
-        Directory where the output plot will be saved.
     """
-    symlinks_dir = Path(symlinks_dir)
-    plot_dir = Path(plot_dir)
-
-    pointcloud_files = list((symlinks_dir / "dense_pointclouds").iterdir())
+    pointcloud_files = list((config.proc_dir.symlinks_dir / "dense_pointclouds").iterdir())
     df = stats.compute_pcs_statistics_df(pointcloud_files)
-    viz.barplot_var(df, plot_dir / "pointcloud_point_count.png", "point_count", "Point count in dense point-cloud file")
+    viz.barplot_var(df, config.plot_dir / "pointcloud_point_count.png", "point_count", "Point count in dense point-cloud file")
+    
+    viz.visualize_files_presence_map(list(config.proc_dir.symlinks_dir.iterdir()), config.plot_dir / "submissions_presence_map.png")
 
-
-def plot_point2dem(raw_dems_dir: str | Path, plot_dir: str | Path, max_workers: int | None = None) -> None:
+def plot_point2dem(config: Config) -> None:
     """
     Generate plots for the raw DEMs produced by the point-cloud-to-DEM step.
 
     Saves a bar chart of nodata percentages and per-(site, dataset) DEM mosaics
     for all raw DEMs found in ``raw_dems_dir``.
-
-    Parameters
-    ----------
-    raw_dems_dir : str or Path
-        Directory containing raw DEM files (``*-DEM.tif``).
-    plot_dir : str or Path
-        Directory where output plots will be saved.
-    max_workers : int or None, optional
-        Number of parallel workers for computing DEM statistics. Defaults to None.
     """
-    raw_dems_dir = Path(raw_dems_dir)
-    plot_dir = Path(plot_dir)
 
-    df = stats.compute_dems_statistics_df(raw_dems_dir.glob("*-DEM.tif"), max_workers=max_workers)
-    viz.barplot_var(df, plot_dir / "raw_dem_voids.png", "percent_nodata", "Raw DEM nodata percent")
+    df = stats.compute_dems_statistics_df(config.proc_dir.raw_dems_dir.glob("*-DEM.tif"), max_workers=config.max_workers)
+    viz.barplot_var(df, config.plot_dir / "raw_dem_voids.png", "percent_nodata", "Raw DEM nodata percent")
     for (site, dataset), group in df.groupby(["site", "dataset"]):
-        output_path = plot_dir / f"{site}_{dataset}" / "mosaic" / "mosaic_raw_dem.png"
+        output_path = config.plot_dir / f"{site}_{dataset}" / "mosaic" / "mosaic_raw_dem.png"
         vmin, vmax = group["min"].median(), group["max"].median()
         viz.generate_dems_mosaic(group["file"].to_dict(), output_path, vmin, vmax, f"({site} {dataset}) Mosaic Raw DEMs")
 
 
-def plot_coregistration(coreg_dems_dir: str | Path, plot_dir: str | Path, max_workers: int | None = None) -> None:
+def plot_coregistration(config: Config) -> None:
     """
     Generate plots summarizing the coregistration step.
 
     Saves per-(site, dataset) DEM mosaics and coregistration-shift scatter plots
-    for all coregistered DEMs in ``coreg_dems_dir``.
-
-    Parameters
-    ----------
-    coreg_dems_dir : str or Path
-        Directory containing coregistered DEM files (``*-DEM.tif``).
-    plot_dir : str or Path
-        Directory where output plots will be saved.
-    max_workers : int or None, optional
-        Number of parallel workers for computing DEM statistics. Defaults to None.
+    for all coregistered DEMs in ``coreg_dems_dir``. When ``symlinks_dir`` and
+    ``raw_dems_dir`` are provided, also saves an updated submissions presence map
+    that includes the raw and coregistered DEM directories.
     """
-    coreg_dems_dir = Path(coreg_dems_dir)
-    plot_dir = Path(plot_dir)
+    coreg_dems_dir = config.proc_dir.coreg_dems_dir
+    raw_dems_dir = config.proc_dir.raw_dems_dir
+    symlinks_dir = config.proc_dir.symlinks_dir
 
-    df = stats.compute_dems_statistics_df(coreg_dems_dir.glob("*-DEM.tif"), max_workers=max_workers)
+    df = stats.compute_dems_statistics_df(coreg_dems_dir.glob("*-DEM.tif"), max_workers=config.max_workers)
     for (site, dataset), group in df.groupby(["site", "dataset"]):
-        output_path = plot_dir / f"{site}_{dataset}" / "mosaic" / "mosaic_coreg_dem.png"
+        output_path = config.plot_dir / f"{site}_{dataset}" / "mosaic" / "mosaic_coreg_dem.png"
         vmin, vmax = group["min"].median(), group["max"].median()
         viz.generate_dems_mosaic(group["file"].to_dict(), output_path, vmin, vmax, f"({site} {dataset}) Mosaic Coregistered DEMs")
 
     df_shifts = stats.get_coregistration_statistics_df(coreg_dems_dir.glob("*-DEM.tif"))
     for (site, dataset), group in df_shifts.groupby(["site", "dataset"]):
-        output_path = plot_dir / f"{site}_{dataset}" / "coregistration_shifts.png"
+        output_path = config.plot_dir / f"{site}_{dataset}" / "coregistration_shifts.png"
         viz.generate_plot_coreg_shifts(group, output_path, f"({site} {dataset}) Coregistration shifts")
 
+    if symlinks_dir is not None and raw_dems_dir is not None:
+        directories = list(Path(symlinks_dir).iterdir()) + [Path(raw_dems_dir), coreg_dems_dir]
+        viz.visualize_files_presence_map(directories, config.plot_dir / "submissions_presence_map.png")
 
-def plot_ddems(
-    before_coreg_ddems_dir: str | Path,
-    after_coreg_ddems_dir: str | Path,
-    plot_dir: str | Path,
-    overwrite: bool = False,
-    max_workers: int | None = None,
-) -> None:
+
+def plot_ddems(config: Config) -> None:
     """
     Generate plots comparing dDEMs before and after coregistration.
 
     Saves a global NMAD bar chart, per-(site, dataset) NMAD before-vs-after plots,
     per-submission coregistration plots, and mosaics of dDEMs, slopes, and hillshades.
-
-    Parameters
-    ----------
-    before_coreg_ddems_dir : str or Path
-        Directory containing dDEM files computed before coregistration (``*-DDEM.tif``).
-    after_coreg_ddems_dir : str or Path
-        Directory containing dDEM files computed after coregistration (``*-DDEM.tif``).
-    plot_dir : str or Path
-        Directory where output plots will be saved.
-    overwrite : bool, optional
-        If True, existing individual coregistration plots are overwritten. Default is False.
-    max_workers : int or None, optional
-        Number of parallel workers for computing DEM statistics. Defaults to None.
     """
-    before_coreg_ddems_dir = Path(before_coreg_ddems_dir)
-    after_coreg_ddems_dir = Path(after_coreg_ddems_dir)
-    plot_dir = Path(plot_dir)
+    before_coreg_ddems_dir = config.proc_dir.before_coreg_ddems_dir
+    after_coreg_ddems_dir = config.proc_dir.after_coreg_ddems_dir
 
-    ddem_before_df = stats.compute_dems_statistics_df(before_coreg_ddems_dir.glob("*-DDEM.tif"), "ddem_before_", max_workers)
-    ddem_after_df = stats.compute_dems_statistics_df(after_coreg_ddems_dir.glob("*-DDEM.tif"), "ddem_after_", max_workers)
+    ddem_before_df = stats.compute_dems_statistics_df(before_coreg_ddems_dir.glob("*-DDEM.tif"), "ddem_before_", config.max_workers)
+    ddem_after_df = stats.compute_dems_statistics_df(after_coreg_ddems_dir.glob("*-DDEM.tif"), "ddem_after_", config.max_workers)
     df = pd.concat([ddem_before_df, ddem_after_df]).groupby(level=0).first()
 
-    viz.barplot_var(df, plot_dir / "nmad_after_coregistration.png", "ddem_after_nmad", "NMAD of Altitude differences with ref DEM after coregistration by code")
+    viz.barplot_var(df, config.plot_dir / "nmad_after_coregistration.png", "ddem_after_nmad", "NMAD of Altitude differences with ref DEM after coregistration by code")
 
     for (site, dataset), group in df.groupby(["site", "dataset"]):
-        sub_dir = plot_dir / f"{site}_{dataset}"
+        sub_dir = config.plot_dir / f"{site}_{dataset}"
         viz.generate_plot_nmad_before_vs_after(group, sub_dir / "nmad_before_vs_after_coregistration.png", f"({site} {dataset}) NMAD of DEM differences before vs after coregistration")
-        viz.generate_coregistration_individual_plots(group, sub_dir / "coregistrations", overwrite)
+        viz.generate_coregistration_individual_plots(group, sub_dir / "coregistrations", config.overwrite)
 
         ddem_files_dict = group["ddem_after_file"].dropna().to_dict()
         viz.generate_ddems_mosaic(ddem_files_dict, sub_dir / "mosaic" / "mosaic_ddem.png", f"({site} {dataset}) Mosaic of DDEMs after coregistration")
@@ -1189,67 +1147,36 @@ def plot_ddems(
         viz.generate_hillshades_mosaic(ddem_files_dict, sub_dir / "mosaic" / "mosaic_hillshades_ddem.png", f"({site} {dataset}) Mosaic hillshades of DDEMs after coregistration")
 
 
-def plot_std_dems(std_dems_dir: str | Path, plot_dir: str | Path) -> None:
+def plot_std_dems(config: Config) -> None:
     """
     Generate plots for each STD DEM found in ``std_dems_dir``.
-
-    Parameters
-    ----------
-    std_dems_dir : str or Path
-        Directory containing STD DEM files (``*.tif``).
-    plot_dir : str or Path
-        Directory where output plots will be saved. Each STD DEM produces a
-        ``.png`` in a subdirectory named after the DEM stem (without ``_std_dem``).
     """
-    std_dems_dir = Path(std_dems_dir)
-    plot_dir = Path(plot_dir)
-
-    for file in std_dems_dir.glob("*.tif"):
+    for file in config.proc_dir.std_dems_dir.glob("*.tif"):
         subdir = file.stem.replace("_std_dem", "")
-        output_path = plot_dir / subdir / file.with_suffix(".png").name
+        output_path = config.plot_dir / subdir / file.with_suffix(".png").name
         viz.generate_std_dem_plots(file, output_path)
 
 
-def plot_landcover(
-    after_coreg_ddems_dir: str | Path,
-    std_dems_dir: str | Path,
-    references_data: ReferencesData,
-    plot_dir: str | Path,
-    max_workers: int | None = None,
-) -> None:
+def plot_landcover(config: Config) -> None:
     """
     Generate landcover-stratified plots for dDEMs and STD DEMs.
 
     Computes landcover-stratified statistics on coregistered dDEMs and STD DEMs,
     then saves per-(site, dataset) grouped boxplots and NMAD plots, as well as
     a global boxplot aggregated from all STD DEMs.
-
-    Parameters
-    ----------
-    after_coreg_ddems_dir : str or Path
-        Directory containing coregistered dDEM files (``*-DDEM.tif``).
-    std_dems_dir : str or Path
-        Directory containing STD DEM files (``*.tif``).
-    references_data : ReferencesData
-        Object providing landcover raster paths for each (site, dataset) pair.
-    plot_dir : str or Path
-        Directory where output plots will be saved.
-    max_workers : int or None, optional
-        Number of parallel workers for computing statistics. Defaults to None.
     """
-    after_coreg_ddems_dir = Path(after_coreg_ddems_dir)
-    std_dems_dir = Path(std_dems_dir)
-    plot_dir = Path(plot_dir)
+    after_coreg_ddems_dir = config.proc_dir.after_coreg_ddems_dir
+    std_dems_dir = config.proc_dir.std_dems_dir
 
-    landcover_df = stats.compute_landcover_statistics(after_coreg_ddems_dir.glob("*-DDEM.tif"), references_data, max_workers)
-    std_lc_df = stats.compute_landcover_statistics_on_std_dems(std_dems_dir.glob("*.tif"), references_data, max_workers)
+    landcover_df = stats.compute_landcover_statistics(after_coreg_ddems_dir.glob("*-DDEM.tif"), config.references_data_mapping, config.max_workers)
+    std_lc_df = stats.compute_landcover_statistics_on_std_dems(std_dems_dir.glob("*.tif"), config.references_data_mapping, config.max_workers)
 
     for (site, dataset), group in landcover_df.groupby(["site", "dataset"]):
-        sub_dir = plot_dir / f"{site}_{dataset}"
+        sub_dir = config.plot_dir / f"{site}_{dataset}"
         viz.generate_landcover_grouped_boxplot(group, sub_dir / "landcover_grouped_boxplot.png", f"({site} {dataset}) Boxplot of Altitude difference with ref DEM by code/landcover")
         viz.generate_landcover_nmad(group, sub_dir / "landcover_nmad.png", f"({site} {dataset}) NMAD of Altitude difference with ref DEM by code/landcover")
 
-    viz.generate_landcover_grouped_boxplot_from_std_dems(std_lc_df, plot_dir / "landcover_boxplot_from_std_dems.png")
+    viz.generate_landcover_grouped_boxplot_from_std_dems(std_lc_df, config.plot_dir / "landcover_boxplot_from_std_dems.png")
 
 
 #######################################################################################################################

--- a/src/history/postprocessing/pipeline.py
+++ b/src/history/postprocessing/pipeline.py
@@ -31,6 +31,7 @@ import zipfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Iterable
+from collections import Counter
 
 import geoutils as gu
 import humanize
@@ -45,6 +46,7 @@ from rasterio.windows import Window
 from shapely import box, transform
 from tqdm import tqdm
 
+import history.postprocessing.io as io
 import history.postprocessing.statistics as stats
 import history.postprocessing.visualization as viz
 from history.postprocessing.io import ReferencesData, parse_filename
@@ -216,6 +218,79 @@ def index_submissions_and_link_files(input_dir: str | Path, output_dir: str, ove
                     link.unlink()
                 link.symlink_to(row[colname])
 
+
+def check_planned_submissions(
+    pointcloud_files: list[str | Path],
+    planned_outfile: str | Path,
+):
+    """
+    Check received/processed submissions against planned submissions filled in shared Google sheet.
+
+    Google sheet file is downloaded and converted to CSV with gdown.
+    Submitted experiment codes are extracted from point cloud filenames and compared to planned results.
+
+    Parameters
+    ----------
+    pointcloud_files : list[str | Path]
+        List of extracted point cloud file paths.
+    planned_outfile : str or Path
+        Location where to save the planned CSV file, that is downloaded from GDrive and updated.
+    """
+    pointcloud_files: list[Path] = [Path(f) for f in pointcloud_files]
+    planned_outfile = Path(planned_outfile)
+
+    # Download planned submissions from shared sheet
+    planned_df = io.download_planned_submissions(planned_outfile)
+
+    # Extract experiment codes of processed point clouds
+    processed_success_codes = []
+    processed_fail_codes = []
+    for file in pointcloud_files:
+        try:
+            code, metadatas = parse_filename(file)
+            processed_success_codes.append(code)
+        except Exception as e:
+            logger.error(f"Error processing {file.name}: {e}")
+            # Try to extract code even if not matching expected pattern
+            code = "_".join(file.stem.split("_")[:-2])
+            processed_fail_codes.append(code)
+            continue
+
+    # Check processed codes are unique
+    all_codes = processed_success_codes + processed_fail_codes
+    counts = Counter(all_codes)
+    non_uniques = [x for x in all_codes if counts[x] > 1]
+    if len(non_uniques) > 0:
+        logger.warning(f"Found {len(non_uniques)} non unique codes:")
+        for code in non_uniques:
+            logger.warning(f"\t{code}")
+
+    # Find received, successully processed and unplanned submissions
+    set_processed = set(processed_success_codes)
+    set_planned = set(planned_df["Submission code"])
+
+    received = planned_df["Submission code"].map(lambda x: x in all_codes)
+    planned_df["received"] = received
+
+    processed = planned_df["Submission code"].map(lambda x: x in processed_success_codes)
+    planned_df["processed"] = processed
+
+    unplanned = set_processed - set_planned
+
+    print(f"Found {len(planned_df[~planned_df['received']])} unsubmitted results")
+    for code in planned_df[~planned_df['received']]["Submission code"]:
+        print(f"\t{code}")
+
+    print(f"Found {len(unplanned)} unplanned results")
+    for code in sorted(unplanned):
+        print(f"\t{code}")
+
+    # print("\nTo update 'received' column on sheet, copy/paste below:")
+    # for res in planned_df["received"]:
+    #     print(f"{res}")
+    
+    planned_df.to_csv(planned_outfile)
+    print(f"Updated planned submissions saved to {planned_outfile}. \nOpen and copy in VSCode with command 'edit csv'.")
 
 def process_pointclouds_to_dems(
     pointcloud_files: list[str | Path],

--- a/src/history/postprocessing/pipeline.py
+++ b/src/history/postprocessing/pipeline.py
@@ -224,12 +224,12 @@ def check_planned_submissions(
     if unsubmitted:
         logger.warning(f"{len(unsubmitted)} planned submissions not yet received:")
         for code in sorted(unsubmitted):
-            logger.warning(f"  {code}")
+            logger.info(f"  {code}")
 
     if unplanned:
         logger.warning(f"{len(unplanned)} unplanned submissions received:")
         for code in unplanned:
-            logger.warning(f"  {code}")
+            logger.info(f"  {code}")
 
     planned_df.to_csv(planned_outfile)
     logger.info(f"Updated planned submissions saved to {planned_outfile}.")
@@ -307,8 +307,8 @@ def process_pointclouds_to_dems(
             output_dem_path = output_directory / f"{code}{suffix}.tif"
 
             # avoid overwriting existing DEM
-            if not overwrite and is_output_up_to_date(file, output_dem_path):
-                logger.info(f"Skip point2dem for {code}: output already exists.")
+            if not overwrite and is_output_up_to_date([file, ref_dem_path], output_dem_path):
+                logger.info(f"Skip point2dem for {code}: output is up to date.")
                 continue
 
             args_dict[code] = [file, ref_dem_path, output_dem_path]
@@ -588,7 +588,7 @@ def generate_ddems(
 
             # avoid overwriting existing files
             if not overwrite and is_output_up_to_date([file, ref_dem_path], output_path):
-                logger.info(f"Skip DDEM {code}, output already exists.")
+                logger.info(f"Skip DDEM {code}, output is up to date.")
                 continue
 
             args_dict[code] = [file, ref_dem_path, output_path]
@@ -642,7 +642,7 @@ def create_std_dem(
         return
 
     if not overwrite and io.is_output_up_to_date(dem_files, output_path):
-        logger.info(f"Skip {output_path.name}: output already exists.")
+        logger.info(f"Skip {output_path.name}: output is up to date.")
         return
 
     # first open the first raster of the list to have a reference profile
@@ -1130,7 +1130,7 @@ def plot_symlinks(config: Config, submissions_df: pd.DataFrame | None = None) ->
 
     output_pc_count = config.plot_dir / "pointcloud_point_count.png"
     if not config.overwrite_plots and is_output_up_to_date(pointcloud_files, output_pc_count):
-        logger.info(f"Skip {output_pc_count.name}: output already exists.")
+        logger.info(f"Skip {output_pc_count.name}: output is up to date.")
     else:
         df = stats.compute_pcs_statistics_df(pointcloud_files)
         viz.barplot_var(df, output_pc_count, "point_count", "Point count in dense point-cloud file", overwrite=config.overwrite_plots)

--- a/src/history/postprocessing/pipeline.py
+++ b/src/history/postprocessing/pipeline.py
@@ -150,6 +150,39 @@ def create_symlinks(df: pd.DataFrame, output_dir: str | Path, overwrite: bool = 
             link.symlink_to(row[col])
 
 
+def report_symlinks(config: Config) -> None:
+    """Scan extracted_dir and raw_dir to create symlinks for all report founds"""
+    output_dir = config.proc_dir.symlinks_dir / "reports"
+
+    # remove old symlinks dir and recreate it
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(exist_ok=True, parents=True)
+
+    # find all report 
+    files = list(config.extracted_dir.rglob("*report*")) + list(config.raw_dir.rglob("*report*"))
+
+    # link all files
+    for f in files:
+        link = output_dir / f.name
+        n = 1
+        while link.exists():
+            link = output_dir / f"{f.stem} ({n}){f.suffix}"
+            n += 1
+        link.symlink_to(f)
+
+    # extensions
+    extensions = list(set(f.suffix for f in files))
+
+    logger.info(f"Saved {len(files)} reports to {output_dir} ({len(extensions)} format(s): {', '.join(extensions) or 'none'})")
+        
+
+
+
+     
+
+
+
 def index_submissions_and_link_files(input_dir: str | Path, output_dir: str | Path, overwrite: bool = False) -> None:
     """Scan, validate, and create symlinks for all submissions in *input_dir*.
 

--- a/src/history/postprocessing/pipeline.py
+++ b/src/history/postprocessing/pipeline.py
@@ -1155,7 +1155,7 @@ def plot_point2dem(config: Config) -> None:
     for (site, dataset), group in df.groupby(["site", "dataset"]):
         output_path = config.plot_dir / f"{site}_{dataset}" / "mosaic" / "mosaic_raw_dem.png"
         vmin, vmax = group["min"].median(), group["max"].median()
-        viz.generate_dems_mosaic(group["file"].to_dict(), output_path, vmin, vmax, f"({site} {dataset}) Mosaic Raw DEMs")
+        viz.generate_dems_mosaic(group["file"].to_dict(), output_path, vmin, vmax, f"({site} {dataset}) Mosaic Raw DEMs", config.overwrite)
 
 
 def plot_coregistration(config: Config) -> None:
@@ -1173,9 +1173,12 @@ def plot_coregistration(config: Config) -> None:
 
     df = stats.compute_dems_statistics_df(coreg_dems_dir.glob("*-DEM.tif"), max_workers=config.max_workers)
     for (site, dataset), group in df.groupby(["site", "dataset"]):
-        output_path = config.plot_dir / f"{site}_{dataset}" / "mosaic" / "mosaic_coreg_dem.png"
+        sub_dir = config.plot_dir / f"{site}_{dataset}"
+        dem_files_dict = group["file"].to_dict()
         vmin, vmax = group["min"].median(), group["max"].median()
-        viz.generate_dems_mosaic(group["file"].to_dict(), output_path, vmin, vmax, f"({site} {dataset}) Mosaic Coregistered DEMs")
+        viz.generate_dems_mosaic(dem_files_dict, sub_dir / "mosaic" / "mosaic_coreg_dem.png", vmin, vmax, f"({site} {dataset}) Mosaic Coregistered DEMs", config.overwrite)
+        viz.generate_slopes_mosaic(dem_files_dict, sub_dir / "mosaic" / "mosaic_slopes.png", f"({site} {dataset}) Mosaic slopes of DDEMs after coregistration", config.overwrite)
+        viz.generate_hillshades_mosaic(dem_files_dict, sub_dir / "mosaic" / "mosaic_hillshades.png", f"({site} {dataset}) Mosaic hillshades of DDEMs after coregistration", config.overwrite)
 
     df_shifts = stats.get_coregistration_statistics_df(coreg_dems_dir.glob("*-DEM.tif"))
     for (site, dataset), group in df_shifts.groupby(["site", "dataset"]):
@@ -1209,9 +1212,7 @@ def plot_ddems(config: Config) -> None:
         viz.generate_coregistration_individual_plots(group, sub_dir / "coregistrations", config.overwrite)
 
         ddem_files_dict = group["ddem_after_file"].dropna().to_dict()
-        viz.generate_ddems_mosaic(ddem_files_dict, sub_dir / "mosaic" / "mosaic_ddem.png", title=f"({site} {dataset}) Mosaic of DDEMs after coregistration")
-        viz.generate_slopes_mosaic(ddem_files_dict, sub_dir / "mosaic" / "mosaic_slopes_ddem.png", title=f"({site} {dataset}) Mosaic slopes of DDEMs after coregistration")
-        viz.generate_hillshades_mosaic(ddem_files_dict, sub_dir / "mosaic" / "mosaic_hillshades_ddem.png", title=f"({site} {dataset}) Mosaic hillshades of DDEMs after coregistration")
+        viz.generate_ddems_mosaic(ddem_files_dict, sub_dir / "mosaic" / "mosaic_ddem.png", f"({site} {dataset}) Mosaic of DDEMs after coregistration", config.overwrite)
 
 
 def plot_std_dems(config: Config) -> None:

--- a/src/history/postprocessing/pipeline.py
+++ b/src/history/postprocessing/pipeline.py
@@ -30,8 +30,6 @@ import zipfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Iterable
-import os
-
 import geoutils as gu
 from history.postprocessing.config import Config
 import humanize
@@ -50,7 +48,7 @@ from tqdm import tqdm
 import history.postprocessing.io as io
 import history.postprocessing.statistics as stats
 import history.postprocessing.visualization as viz
-from history.postprocessing.io import ReferencesData, parse_filename
+from history.postprocessing.io import ReferencesData, is_output_up_to_date, parse_filename
 
 logger = logging.getLogger(__name__)
 
@@ -97,8 +95,8 @@ def uncompress_all_submissions(
             continue
 
         output_path = output_dir / input_path.name.split(".")[0]
-        if output_path.exists() and not overwrite:
-            logger.info(f"Skipping extraction (folder exists): {output_path}")
+        if not overwrite and is_output_up_to_date(input_path, output_path):
+            logger.info(f"Skipping extraction (folder up to date): {output_path}")
             continue
         args_list.append((input_path, output_path))
 
@@ -181,12 +179,6 @@ def report_symlinks(config: Config) -> None:
 
     logger.info(f"Saved {len(files)} reports to {output_dir} ({len(extensions)} format(s): {', '.join(extensions) or 'none'})")
         
-
-
-
-     
-
-
 
 def index_submissions_and_link_files(input_dir: str | Path, output_dir: str | Path, overwrite: bool = False) -> None:
     """Scan, validate, and create symlinks for all submissions in *input_dir*.
@@ -315,7 +307,7 @@ def process_pointclouds_to_dems(
             output_dem_path = output_directory / f"{code}{suffix}.tif"
 
             # avoid overwriting existing DEM
-            if output_dem_path.exists() and not overwrite:
+            if not overwrite and is_output_up_to_date(file, output_dem_path):
                 logger.info(f"Skip point2dem for {code}: output already exists.")
                 continue
 
@@ -417,7 +409,7 @@ def add_provided_dems(
 
             # avoid overwriting existing files
             output_path = output_dir / f"{code}{suffix}.tif"
-            if output_path.exists() and not overwrite:
+            if not overwrite and is_output_up_to_date(file, output_path):
                 logger.info(f"Skip {code} output already exists.")
                 continue
 
@@ -495,14 +487,14 @@ def coregister_dems(
 
             output_dem_path = output_dir / file.name
 
-            # avoid overwriting existing files
-            if output_dem_path.exists() and not overwrite:
-                logger.info(f"Skip coregistration for {code}, output already exists.")
-                continue
-
-            # extract corresponding ref dem and mask with site and dataset
+             # extract corresponding ref dem and mask with site and dataset
             ref_dem_path = references_data.get_ref_dem(metadatas["site"], metadatas["dataset"])
             ref_dem_mask_path = references_data.get_ref_dem_mask(metadatas["site"], metadatas["dataset"])
+
+            # avoid overwriting existing files
+            if not overwrite and is_output_up_to_date([file, ref_dem_path, ref_dem_mask_path], output_dem_path):
+                logger.info(f"Skip coregistration for {code}, output already exists.")
+                continue
 
             args_dict[code] = [file, ref_dem_path, ref_dem_mask_path, output_dem_path]
 
@@ -591,13 +583,13 @@ def generate_ddems(
 
             output_path = output_dir / f"{code}{suffix}.tif"
 
-            # avoid overwriting existing files
-            if output_path.exists() and not overwrite:
-                logger.info(f"Skip DDEM {code}, output already exists.")
-                continue
-
             # get corresponding reference DEM with site and dataset
             ref_dem_path = references_data.get_ref_dem(metadatas["site"], metadatas["dataset"])
+
+            # avoid overwriting existing files
+            if not overwrite and is_output_up_to_date([file, ref_dem_path], output_path):
+                logger.info(f"Skip DDEM {code}, output already exists.")
+                continue
 
             args_dict[code] = [file, ref_dem_path, output_path]
         except Exception as e:
@@ -649,12 +641,9 @@ def create_std_dem(
         logger.warning(f"Need at least 2 DEMs for computing the STD DEM: {output_path.name}.")
         return
 
-    if is_existing_std_dem(dem_files, output_path, metadata_key) and not overwrite:
-        all_input_mtimes = [os.path.getmtime(fname) for fname in list(dem_files)]
-        output_mtime = os.path.getmtime(output_path)
-        if output_mtime > np.max(all_input_mtimes):
-            logger.info(f"Skip {output_path.name}: output already exists.")
-            return
+    if not overwrite and io.is_output_up_to_date(dem_files, output_path):
+        logger.info(f"Skip {output_path.name}: output already exists.")
+        return
 
     # first open the first raster of the list to have a reference profile
     with rasterio.open(dem_files[0]) as src_ref:
@@ -1138,13 +1127,18 @@ def plot_symlinks(config: Config, submissions_df: pd.DataFrame | None = None) ->
         file-size matrix is saved alongside the presence map.
     """
     pointcloud_files = list((config.proc_dir.symlinks_dir / "dense_pointclouds").iterdir())
-    df = stats.compute_pcs_statistics_df(pointcloud_files)
-    viz.barplot_var(df, config.plot_dir / "pointcloud_point_count.png", "point_count", "Point count in dense point-cloud file")
 
-    viz.visualize_files_presence_map(list(config.proc_dir.symlinks_dir.iterdir()), config.plot_dir / "submissions_presence_map.png")
+    output_pc_count = config.plot_dir / "pointcloud_point_count.png"
+    if not config.overwrite_plots and is_output_up_to_date(pointcloud_files, output_pc_count):
+        logger.info(f"Skip {output_pc_count.name}: output already exists.")
+    else:
+        df = stats.compute_pcs_statistics_df(pointcloud_files)
+        viz.barplot_var(df, output_pc_count, "point_count", "Point count in dense point-cloud file", overwrite=config.overwrite_plots)
+
+    viz.visualize_files_presence_map(list(config.proc_dir.symlinks_dir.iterdir()), config.plot_dir / "submissions_presence_map.png", overwrite=config.overwrite_plots)
 
     if submissions_df is not None:
-        viz.visualize_files_size_map(submissions_df, config.plot_dir / "submissions_file_sizes.png")
+        viz.visualize_files_size_map(submissions_df, config.plot_dir / "submissions_file_sizes.png", overwrite=config.overwrite_plots)
 
 def plot_point2dem(config: Config) -> None:
     """
@@ -1155,12 +1149,12 @@ def plot_point2dem(config: Config) -> None:
     """
 
     df = stats.compute_dems_statistics_df(config.proc_dir.raw_dems_dir.glob("*-DEM.tif"), max_workers=config.max_workers)
-    viz.barplot_var(df, config.plot_dir / "raw_dem_voids.png", "percent_nodata", "Raw DEM nodata percent")
+    viz.barplot_var(df, config.plot_dir / "raw_dem_voids.png", "percent_nodata", "Raw DEM nodata percent", overwrite=config.overwrite_plots)
     for (site, dataset), group in df.groupby(["site", "dataset"]):
         logger.debug(f"Plotting **** {site} - {dataset} ****")
         output_path = config.plot_dir / f"{site}_{dataset}" / "mosaic" / "mosaic_raw_dem.png"
         vmin, vmax = group["min"].median(), group["max"].median()
-        viz.generate_dems_mosaic(group["file"].to_dict(), output_path, vmin, vmax, f"({site} {dataset}) Mosaic Raw DEMs", config.overwrite)
+        viz.generate_dems_mosaic(group["file"].to_dict(), output_path, vmin, vmax, f"({site} {dataset}) Mosaic Raw DEMs", config.overwrite_plots)
 
 
 def plot_coregistration(config: Config) -> None:
@@ -1184,24 +1178,24 @@ def plot_coregistration(config: Config) -> None:
         vmin, vmax = group["min"].median(), group["max"].median()
 
         logger.debug("Plotting coregistered DEMs mosaic")
-        viz.generate_dems_mosaic(dem_files_dict, sub_dir / "mosaic" / "mosaic_coreg_dem.png", vmin, vmax, f"({site} {dataset}) Mosaic Coregistered DEMs", config.overwrite)
+        viz.generate_dems_mosaic(dem_files_dict, sub_dir / "mosaic" / "mosaic_coreg_dem.png", vmin, vmax, f"({site} {dataset}) Mosaic Coregistered DEMs", config.overwrite_plots)
 
         logger.debug("Plotting slope mosaic")
         viz.generate_slopes_mosaic(dem_files_dict, sub_dir / "mosaic" / "mosaic_slopes.png", 
-                                   title=f"({site} {dataset}) Mosaic slopes of DEMs after coregistration", overwrite=config.overwrite)
+                                   title=f"({site} {dataset}) Mosaic slopes of DEMs after coregistration", overwrite=config.overwrite_plots)
 
         logger.debug("Plotting hillshade mosaic")
         viz.generate_hillshades_mosaic(dem_files_dict, sub_dir / "mosaic" / "mosaic_hillshades.png", 
-                                       title=f"({site} {dataset}) Mosaic hillshades of DEMs after coregistration", overwrite=config.overwrite)
+                                       title=f"({site} {dataset}) Mosaic hillshades of DEMs after coregistration", overwrite=config.overwrite_plots)
 
     df_shifts = stats.get_coregistration_statistics_df(coreg_dems_dir.glob("*-DEM.tif"))
     for (site, dataset), group in df_shifts.groupby(["site", "dataset"]):
         output_path = config.plot_dir / f"{site}_{dataset}" / "coregistration_shifts.png"
-        viz.generate_plot_coreg_shifts(group, output_path, f"({site} {dataset}) Coregistration shifts")
+        viz.generate_plot_coreg_shifts(group, output_path, f"({site} {dataset}) Coregistration shifts", overwrite=config.overwrite_plots)
 
     if symlinks_dir is not None and raw_dems_dir is not None:
         directories = list(Path(symlinks_dir).iterdir()) + [Path(raw_dems_dir), coreg_dems_dir]
-        viz.visualize_files_presence_map(directories, config.plot_dir / "files_presence_map.png")
+        viz.visualize_files_presence_map(directories, config.plot_dir / "files_presence_map.png", overwrite=config.overwrite_plots)
 
 
 def plot_ddems(config: Config) -> None:
@@ -1218,17 +1212,17 @@ def plot_ddems(config: Config) -> None:
     ddem_after_df = stats.compute_dems_statistics_df(after_coreg_ddems_dir.glob("*-DDEM.tif"), "ddem_after_", config.max_workers)
     df = pd.concat([ddem_before_df, ddem_after_df]).groupby(level=0).first()
 
-    viz.barplot_var(df, config.plot_dir / "nmad_after_coregistration.png", "ddem_after_nmad", "NMAD of Altitude differences with ref DEM after coregistration by code")
+    viz.barplot_var(df, config.plot_dir / "nmad_after_coregistration.png", "ddem_after_nmad", "NMAD of Altitude differences with ref DEM after coregistration by code", overwrite=config.overwrite_plots)
 
     for (site, dataset), group in df.groupby(["site", "dataset"]):
         logger.debug(f"Plotting **** {site} - {dataset} ****")
         sub_dir = config.plot_dir / f"{site}_{dataset}"
-        viz.generate_plot_nmad_before_vs_after(group, sub_dir / "nmad_before_vs_after_coregistration.png", f"({site} {dataset}) NMAD of DEM differences before vs after coregistration")
-        viz.generate_coregistration_individual_plots(group, sub_dir / "coregistrations", config.overwrite)
+        viz.generate_plot_nmad_before_vs_after(group, sub_dir / "nmad_before_vs_after_coregistration.png", f"({site} {dataset}) NMAD of DEM differences before vs after coregistration", overwrite=config.overwrite_plots)
+        viz.generate_coregistration_individual_plots(group, sub_dir / "coregistrations", config.overwrite_plots)
 
         ddem_files_dict = group["ddem_after_file"].dropna().to_dict()
         viz.generate_ddems_mosaic(ddem_files_dict, sub_dir / "mosaic" / "mosaic_ddem.png", 
-                                  title=f"({site} {dataset}) Mosaic of DDEMs after coregistration", overwrite=config.overwrite)
+                                  title=f"({site} {dataset}) Mosaic of DDEMs after coregistration", overwrite=config.overwrite_plots)
 
 
 def plot_std_dems(config: Config) -> None:
@@ -1238,7 +1232,7 @@ def plot_std_dems(config: Config) -> None:
     for file in config.proc_dir.std_dems_dir.glob("*.tif"):
         subdir = file.stem.replace("_std_dem", "")
         output_path = config.plot_dir / subdir / file.with_suffix(".png").name
-        viz.generate_std_dem_plots(file, output_path)
+        viz.generate_std_dem_plots(file, output_path, overwrite=config.overwrite_plots)
 
 
 def plot_landcover(config: Config) -> None:
@@ -1257,10 +1251,10 @@ def plot_landcover(config: Config) -> None:
 
     for (site, dataset), group in landcover_df.groupby(["site", "dataset"]):
         sub_dir = config.plot_dir / f"{site}_{dataset}"
-        viz.generate_landcover_grouped_boxplot(group, sub_dir / "landcover_grouped_boxplot.png", f"({site} {dataset}) Boxplot of Altitude difference with ref DEM by code/landcover")
-        viz.generate_landcover_nmad(group, sub_dir / "landcover_nmad.png", f"({site} {dataset}) NMAD of Altitude difference with ref DEM by code/landcover")
+        viz.generate_landcover_grouped_boxplot(group, sub_dir / "landcover_grouped_boxplot.png", f"({site} {dataset}) Boxplot of Altitude difference with ref DEM by code/landcover", overwrite=config.overwrite_plots)
+        viz.generate_landcover_nmad(group, sub_dir / "landcover_nmad.png", f"({site} {dataset}) NMAD of Altitude difference with ref DEM by code/landcover", overwrite=config.overwrite_plots)
 
-    viz.generate_landcover_grouped_boxplot_from_std_dems(std_lc_df, config.plot_dir / "landcover_boxplot_from_std_dems.png")
+    viz.generate_landcover_grouped_boxplot_from_std_dems(std_lc_df, config.plot_dir / "landcover_boxplot_from_std_dems.png", overwrite=config.overwrite_plots)
 
 
 #######################################################################################################################

--- a/src/history/postprocessing/pipeline.py
+++ b/src/history/postprocessing/pipeline.py
@@ -49,7 +49,7 @@ from tqdm import tqdm
 import history.postprocessing.io as io
 import history.postprocessing.statistics as stats
 import history.postprocessing.visualization as viz
-from history.postprocessing.io import ReferencesData, parse_filename
+from history.postprocessing.io import FilenameParseError, ReferencesData, parse_filename
 
 logger = logging.getLogger(__name__)
 
@@ -188,9 +188,14 @@ def index_submissions_and_link_files(input_dir: str | Path, output_dir: str, ove
         for file in all_files:
             try:
                 code, metadatas = parse_filename(file)
-            except ValueError:
+            except FilenameParseError as e:
+                relevant_extensions = {".las", ".laz", ".tif", ".csv"}
+                if file.suffix.lower() in relevant_extensions:
+                    logger.warning(f"Cannot parse filename: {e}")
+                else:
+                    logger.debug(f"Skipping non-submission file: {e}")
                 continue
-
+            
             for column, pattern in patterns.items():
                 if re.search(pattern, file.name, re.IGNORECASE):
                     df.at[code, "submission"] = subdir.name

--- a/src/history/postprocessing/pipeline.py
+++ b/src/history/postprocessing/pipeline.py
@@ -1153,6 +1153,7 @@ def plot_point2dem(config: Config) -> None:
     df = stats.compute_dems_statistics_df(config.proc_dir.raw_dems_dir.glob("*-DEM.tif"), max_workers=config.max_workers)
     viz.barplot_var(df, config.plot_dir / "raw_dem_voids.png", "percent_nodata", "Raw DEM nodata percent")
     for (site, dataset), group in df.groupby(["site", "dataset"]):
+        logger.debug(f"Plotting **** {site} - {dataset} ****")
         output_path = config.plot_dir / f"{site}_{dataset}" / "mosaic" / "mosaic_raw_dem.png"
         vmin, vmax = group["min"].median(), group["max"].median()
         viz.generate_dems_mosaic(group["file"].to_dict(), output_path, vmin, vmax, f"({site} {dataset}) Mosaic Raw DEMs", config.overwrite)
@@ -1173,12 +1174,21 @@ def plot_coregistration(config: Config) -> None:
 
     df = stats.compute_dems_statistics_df(coreg_dems_dir.glob("*-DEM.tif"), max_workers=config.max_workers)
     for (site, dataset), group in df.groupby(["site", "dataset"]):
+        logger.debug(f"Plotting **** {site} - {dataset} ****")
         sub_dir = config.plot_dir / f"{site}_{dataset}"
         dem_files_dict = group["file"].to_dict()
         vmin, vmax = group["min"].median(), group["max"].median()
+
+        logger.debug("Plotting coregistered DEMs mosaic")
         viz.generate_dems_mosaic(dem_files_dict, sub_dir / "mosaic" / "mosaic_coreg_dem.png", vmin, vmax, f"({site} {dataset}) Mosaic Coregistered DEMs", config.overwrite)
-        viz.generate_slopes_mosaic(dem_files_dict, sub_dir / "mosaic" / "mosaic_slopes.png", f"({site} {dataset}) Mosaic slopes of DDEMs after coregistration", config.overwrite)
-        viz.generate_hillshades_mosaic(dem_files_dict, sub_dir / "mosaic" / "mosaic_hillshades.png", f"({site} {dataset}) Mosaic hillshades of DDEMs after coregistration", config.overwrite)
+
+        logger.debug("Plotting slope mosaic")
+        viz.generate_slopes_mosaic(dem_files_dict, sub_dir / "mosaic" / "mosaic_slopes.png", 
+                                   title=f"({site} {dataset}) Mosaic slopes of DEMs after coregistration", overwrite=config.overwrite)
+
+        logger.debug("Plotting hillshade mosaic")
+        viz.generate_hillshades_mosaic(dem_files_dict, sub_dir / "mosaic" / "mosaic_hillshades.png", 
+                                       title=f"({site} {dataset}) Mosaic hillshades of DEMs after coregistration", overwrite=config.overwrite)
 
     df_shifts = stats.get_coregistration_statistics_df(coreg_dems_dir.glob("*-DEM.tif"))
     for (site, dataset), group in df_shifts.groupby(["site", "dataset"]):
@@ -1212,7 +1222,8 @@ def plot_ddems(config: Config) -> None:
         viz.generate_coregistration_individual_plots(group, sub_dir / "coregistrations", config.overwrite)
 
         ddem_files_dict = group["ddem_after_file"].dropna().to_dict()
-        viz.generate_ddems_mosaic(ddem_files_dict, sub_dir / "mosaic" / "mosaic_ddem.png", f"({site} {dataset}) Mosaic of DDEMs after coregistration", config.overwrite)
+        viz.generate_ddems_mosaic(ddem_files_dict, sub_dir / "mosaic" / "mosaic_ddem.png", 
+                                  title=f"({site} {dataset}) Mosaic of DDEMs after coregistration", overwrite=config.overwrite)
 
 
 def plot_std_dems(config: Config) -> None:

--- a/src/history/postprocessing/pipeline.py
+++ b/src/history/postprocessing/pipeline.py
@@ -1062,18 +1062,28 @@ def is_existing_std_dem(dem_files: list[str | Path], output_path: str | Path, me
 #######################################################################################################################
 
 
-def plot_symlinks(config: Config) -> None:
+def plot_symlinks(config: Config, submissions_df: pd.DataFrame | None = None) -> None:
     """
     Generate plots summarizing the indexed symlinks directory.
 
     Computes point-cloud statistics from dense point cloud files and saves
     a bar chart of point counts per submission.
+
+    Parameters
+    ----------
+    config : Config
+    submissions_df : pd.DataFrame, optional
+        DataFrame returned by :func:`io.scan_submissions`.  When provided, a
+        file-size matrix is saved alongside the presence map.
     """
     pointcloud_files = list((config.proc_dir.symlinks_dir / "dense_pointclouds").iterdir())
     df = stats.compute_pcs_statistics_df(pointcloud_files)
     viz.barplot_var(df, config.plot_dir / "pointcloud_point_count.png", "point_count", "Point count in dense point-cloud file")
-    
+
     viz.visualize_files_presence_map(list(config.proc_dir.symlinks_dir.iterdir()), config.plot_dir / "submissions_presence_map.png")
+
+    if submissions_df is not None:
+        viz.visualize_files_size_map(submissions_df, config.plot_dir / "submissions_file_sizes.png")
 
 def plot_point2dem(config: Config) -> None:
     """

--- a/src/history/postprocessing/pipeline.py
+++ b/src/history/postprocessing/pipeline.py
@@ -144,7 +144,9 @@ def create_symlinks(df: pd.DataFrame, output_dir: str | Path, overwrite: bool = 
         for col, subdir_name in io._FILE_COL_TO_SUBDIR.items():
             if col not in row or pd.isna(row[col]):
                 continue
-            link = output_dir / subdir_name / Path(row[col]).name
+            name_col = col.removesuffix("_file") + "_name"
+            link_name = row[name_col] if (name_col in row and pd.notna(row.get(name_col))) else Path(row[col]).name
+            link = output_dir / subdir_name / link_name
             link.parent.mkdir(exist_ok=True, parents=True)
             if link.is_symlink():
                 link.unlink()

--- a/src/history/postprocessing/pipeline.py
+++ b/src/history/postprocessing/pipeline.py
@@ -641,7 +641,7 @@ def create_std_dem(
         logger.warning(f"Need at least 2 DEMs for computing the STD DEM: {output_path.name}.")
         return
 
-    if not overwrite and io.is_output_up_to_date(dem_files, output_path):
+    if not overwrite and io.is_output_up_to_date(dem_files, output_path) and is_existing_std_dem(dem_files, output_path):
         logger.info(f"Skip {output_path.name}: output is up to date.")
         return
 
@@ -728,6 +728,88 @@ def create_std_dems(
     for (site, dataset), files in groups.items():
         output_path = output_dir / f"{site}_{dataset}_std_dem.tif"
         create_std_dem(dem_files=files, output_path=output_path, overwrite=overwrite)
+
+
+#######################################################################################################################
+##                                                  CLEANUP FUNCTIONS
+#######################################################################################################################
+
+
+def cleanup_orphaned_extracted(raw_dir: Path, extracted_dir: Path) -> None:
+    """Remove extracted folders whose source archive no longer exists in raw_dir."""
+    if not extracted_dir.exists():
+        return
+    archive_stems = {p.name.split(".")[0] for p in raw_dir.iterdir() if p.suffix not in [".docx", ".pdf", ".odt"]}
+    for folder in extracted_dir.iterdir():
+        if folder.is_dir() and folder.name not in archive_stems:
+            logger.info(f"Removing orphaned extracted folder (source archive gone): {folder.name}")
+            shutil.rmtree(folder)
+
+
+def cleanup_orphaned_raw_dems(raw_dems_dir: Path, symlinks_dir: Path) -> None:
+    """Remove raw DEMs whose source pointcloud or provided DEM symlink no longer exists."""
+    if not raw_dems_dir.exists():
+        return
+    valid_codes: set[str] = set()
+    for subdir in ["dense_pointclouds", "dems"]:
+        src_dir = symlinks_dir / subdir
+        if src_dir.exists():
+            for f in src_dir.iterdir():
+                try:
+                    code, _ = parse_filename(f)
+                    valid_codes.add(code)
+                except ValueError:
+                    pass
+    for dem_file in raw_dems_dir.glob("*-DEM.tif"):
+        try:
+            code, _ = parse_filename(dem_file)
+            if code not in valid_codes:
+                logger.info(f"Removing orphaned raw DEM (source gone): {dem_file.name}")
+                dem_file.unlink()
+        except ValueError:
+            pass
+
+
+def cleanup_orphaned_coreg_dems(coreg_dems_dir: Path, raw_dems_dir: Path) -> None:
+    """Remove coregistered DEMs whose source raw DEM no longer exists."""
+    if not coreg_dems_dir.exists():
+        return
+    raw_codes: set[str] = set()
+    if raw_dems_dir.exists():
+        for f in raw_dems_dir.glob("*-DEM.tif"):
+            try:
+                raw_codes.add(parse_filename(f)[0])
+            except ValueError:
+                pass
+    for dem_file in coreg_dems_dir.glob("*-DEM.tif"):
+        try:
+            code, _ = parse_filename(dem_file)
+            if code not in raw_codes:
+                logger.info(f"Removing orphaned coregistered DEM (source gone): {dem_file.name}")
+                dem_file.unlink()
+        except ValueError:
+            pass
+
+
+def cleanup_orphaned_ddems(ddems_dir: Path, source_dems_dir: Path) -> None:
+    """Remove dDEMs whose source DEM no longer exists."""
+    if not ddems_dir.exists():
+        return
+    source_codes: set[str] = set()
+    if source_dems_dir.exists():
+        for f in source_dems_dir.glob("*-DEM.tif"):
+            try:
+                source_codes.add(parse_filename(f)[0])
+            except ValueError:
+                pass
+    for ddem_file in ddems_dir.glob("*-DDEM.tif"):
+        try:
+            code, _ = parse_filename(ddem_file)
+            if code not in source_codes:
+                logger.info(f"Removing orphaned dDEM (source gone): {ddem_file.name}")
+                ddem_file.unlink()
+        except ValueError:
+            pass
 
 
 #######################################################################################################################
@@ -914,7 +996,7 @@ def coregister_dem(
 
     # save the coregistered dem
     Path(output_dem_path).parent.mkdir(parents=True, exist_ok=True)
-    dem_coreg.save(output_dem_path, tiled=True)
+    dem_coreg.save(output_dem_path)
 
     # --- Add metadata tags using rasterio ---
     with rasterio.open(output_dem_path, "r+") as dst:

--- a/src/history/postprocessing/pipeline.py
+++ b/src/history/postprocessing/pipeline.py
@@ -1137,7 +1137,8 @@ def plot_symlinks(config: Config, submissions_df: pd.DataFrame | None = None) ->
         df = stats.compute_pcs_statistics_df(pointcloud_files)
         viz.barplot_var(df, output_pc_count, "point_count", "Point count in dense point-cloud file", overwrite=True)
 
-    viz.visualize_files_presence_map(list(config.proc_dir.symlinks_dir.iterdir()), config.plot_dir / "submissions_presence_map.png", overwrite=config.overwrite_plots)
+    directories = [d for d in config.proc_dir.symlinks_dir.iterdir() if d.name != "reports"]
+    viz.visualize_files_presence_map(directories, config.plot_dir / "submissions_presence_map.png", overwrite=config.overwrite_plots)
 
     if submissions_df is not None:
         viz.visualize_files_size_map(submissions_df, config.plot_dir / "submissions_file_sizes.png", overwrite=config.overwrite_plots)
@@ -1190,13 +1191,17 @@ def plot_coregistration(config: Config) -> None:
         viz.generate_hillshades_mosaic(dem_files_dict, sub_dir / "mosaic" / "mosaic_hillshades.png", 
                                        title=f"({site} {dataset}) Mosaic hillshades of DEMs after coregistration", overwrite=config.overwrite_plots)
 
+    # Build per-(site, dataset) file mapping from df (which has the "file" column)
+    coreg_files_by_group = {key: list(g["file"]) for key, g in df.groupby(["site", "dataset"])}
+
     df_shifts = stats.get_coregistration_statistics_df(coreg_dems_dir.glob("*-DEM.tif"))
     for (site, dataset), group in df_shifts.groupby(["site", "dataset"]):
         output_path = config.plot_dir / f"{site}_{dataset}" / "coregistration_shifts.png"
-        viz.generate_plot_coreg_shifts(group, output_path, f"({site} {dataset}) Coregistration shifts", overwrite=config.overwrite_plots)
+        viz.generate_plot_coreg_shifts(group, output_path, f"({site} {dataset}) Coregistration shifts",
+                                       overwrite=config.overwrite_plots, inputs=coreg_files_by_group.get((site, dataset)))
 
     if symlinks_dir is not None and raw_dems_dir is not None:
-        directories = list(Path(symlinks_dir).iterdir()) + [Path(raw_dems_dir), coreg_dems_dir]
+        directories = [d for d in Path(symlinks_dir).iterdir() if d.name != "reports"] + [Path(raw_dems_dir), coreg_dems_dir]
         viz.visualize_files_presence_map(directories, config.plot_dir / "files_presence_map.png", overwrite=config.overwrite_plots)
 
 
@@ -1248,15 +1253,30 @@ def plot_landcover(config: Config) -> None:
     after_coreg_ddems_dir = config.proc_dir.after_coreg_ddems_dir
     std_dems_dir = config.proc_dir.std_dems_dir
 
-    landcover_df = stats.compute_landcover_statistics(after_coreg_ddems_dir.glob("*-DDEM.tif"), config.references_data_mapping, config.max_workers)
+    all_ddem_files = list(after_coreg_ddems_dir.glob("*-DDEM.tif"))
+    ddem_files_by_group: dict[tuple, list[Path]] = {}
+    for f in all_ddem_files:
+        try:
+            _, meta = parse_filename(f)
+            key = (meta["site"], meta["dataset"])
+            ddem_files_by_group.setdefault(key, []).append(f)
+        except Exception:
+            pass
+
+    landcover_df = stats.compute_landcover_statistics(all_ddem_files, config.references_data_mapping, config.max_workers)
     std_lc_df = stats.compute_landcover_statistics_on_std_dems(std_dems_dir.glob("*.tif"), config.references_data_mapping, config.max_workers)
 
     for (site, dataset), group in landcover_df.groupby(["site", "dataset"]):
         sub_dir = config.plot_dir / f"{site}_{dataset}"
-        viz.generate_landcover_grouped_boxplot(group, sub_dir / "landcover_grouped_boxplot.png", f"({site} {dataset}) Boxplot of Altitude difference with ref DEM by code/landcover", overwrite=config.overwrite_plots)
-        viz.generate_landcover_nmad(group, sub_dir / "landcover_nmad.png", f"({site} {dataset}) NMAD of Altitude difference with ref DEM by code/landcover", overwrite=config.overwrite_plots)
+        group_inputs = ddem_files_by_group.get((site, dataset))
+        viz.generate_landcover_grouped_boxplot(group, sub_dir / "landcover_grouped_boxplot.png", f"({site} {dataset}) Boxplot of Altitude difference with ref DEM by code/landcover",
+                                               overwrite=config.overwrite_plots, inputs=group_inputs)
+        viz.generate_landcover_nmad(group, sub_dir / "landcover_nmad.png", f"({site} {dataset}) NMAD of Altitude difference with ref DEM by code/landcover",
+                                    overwrite=config.overwrite_plots, inputs=group_inputs)
 
-    viz.generate_landcover_grouped_boxplot_from_std_dems(std_lc_df, config.plot_dir / "landcover_boxplot_from_std_dems.png", overwrite=config.overwrite_plots)
+    std_dem_files = list(std_dems_dir.glob("*.tif"))
+    viz.generate_landcover_grouped_boxplot_from_std_dems(std_lc_df, config.plot_dir / "landcover_boxplot_from_std_dems.png",
+                                                         overwrite=config.overwrite_plots, inputs=std_dem_files)
 
 
 #######################################################################################################################

--- a/src/history/postprocessing/pipeline.py
+++ b/src/history/postprocessing/pipeline.py
@@ -1034,6 +1034,7 @@ def extract_archive(archive_path: Path | str, output_dir: Path | str, flatten_ne
         # Now 'current' is the deepest redundant folder
         # Move everything back one time at the top-level
         for item in current.iterdir():
+            item.touch()  # Update file time
             shutil.move(str(item), output_dir)
 
         # Now delete entire chain of empty redundant folders
@@ -1127,13 +1128,14 @@ def plot_symlinks(config: Config, submissions_df: pd.DataFrame | None = None) ->
         file-size matrix is saved alongside the presence map.
     """
     pointcloud_files = list((config.proc_dir.symlinks_dir / "dense_pointclouds").iterdir())
+    logger.info("Plotting PC count, presence map and file size.")
 
     output_pc_count = config.plot_dir / "pointcloud_point_count.png"
     if not config.overwrite_plots and is_output_up_to_date(pointcloud_files, output_pc_count):
         logger.info(f"Skip {output_pc_count.name}: output is up to date.")
     else:
         df = stats.compute_pcs_statistics_df(pointcloud_files)
-        viz.barplot_var(df, output_pc_count, "point_count", "Point count in dense point-cloud file", overwrite=config.overwrite_plots)
+        viz.barplot_var(df, output_pc_count, "point_count", "Point count in dense point-cloud file", overwrite=True)
 
     viz.visualize_files_presence_map(list(config.proc_dir.symlinks_dir.iterdir()), config.plot_dir / "submissions_presence_map.png", overwrite=config.overwrite_plots)
 

--- a/src/history/postprocessing/pipeline.py
+++ b/src/history/postprocessing/pipeline.py
@@ -737,10 +737,10 @@ def convert_pointcloud_to_dem(
     ref_dem = gu.Raster(reference_dem_path)
     ref_crs = ref_dem.crs
     if ref_crs is None:
-        raise ValueError(f"The reference dem {reference_dem_path} as no CRS.")
+        raise ValueError(f"The reference dem {reference_dem_path} has no CRS.")
     ref_box = box(*ref_dem.bounds)
 
-    # if not crs found in pc_crs test with a list of CRS
+    # if no crs found in pc_crs, tests with a list of CRS
     if pc_crs is None:
         test_crs_list = [str(ref_crs), "EPSG:4326"]
 
@@ -1152,9 +1152,9 @@ def plot_ddems(config: Config) -> None:
         viz.generate_coregistration_individual_plots(group, sub_dir / "coregistrations", config.overwrite)
 
         ddem_files_dict = group["ddem_after_file"].dropna().to_dict()
-        viz.generate_ddems_mosaic(ddem_files_dict, sub_dir / "mosaic" / "mosaic_ddem.png", f"({site} {dataset}) Mosaic of DDEMs after coregistration")
-        viz.generate_slopes_mosaic(ddem_files_dict, sub_dir / "mosaic" / "mosaic_slopes_ddem.png", f"({site} {dataset}) Mosaic slopes of DDEMs after coregistration")
-        viz.generate_hillshades_mosaic(ddem_files_dict, sub_dir / "mosaic" / "mosaic_hillshades_ddem.png", f"({site} {dataset}) Mosaic hillshades of DDEMs after coregistration")
+        viz.generate_ddems_mosaic(ddem_files_dict, sub_dir / "mosaic" / "mosaic_ddem.png", title=f"({site} {dataset}) Mosaic of DDEMs after coregistration")
+        viz.generate_slopes_mosaic(ddem_files_dict, sub_dir / "mosaic" / "mosaic_slopes_ddem.png", title=f"({site} {dataset}) Mosaic slopes of DDEMs after coregistration")
+        viz.generate_hillshades_mosaic(ddem_files_dict, sub_dir / "mosaic" / "mosaic_hillshades_ddem.png", title=f"({site} {dataset}) Mosaic hillshades of DDEMs after coregistration")
 
 
 def plot_std_dems(config: Config) -> None:

--- a/src/history/postprocessing/pipeline.py
+++ b/src/history/postprocessing/pipeline.py
@@ -40,6 +40,7 @@ import pandas as pd
 import py7zr
 import rasterio
 import xdem
+from pyproj import CRS as ProjCRS
 from pyproj import Transformer
 from rasterio.windows import Window
 from shapely import box, transform
@@ -757,6 +758,12 @@ def convert_pointcloud_to_dem(
     if pc_crs is None:
         raise ValueError(f"{pointcloud_path.name} : Can't find a valid CRS")
 
+    if not ProjCRS.from_user_input(pc_crs).equals(ProjCRS.from_user_input(ref_crs)):
+        logger.warning(
+            f"{pointcloud_path.name}: CRS mismatch — point cloud CRS is {ProjCRS.from_user_input(pc_crs).to_epsg() or pc_crs},"
+            f" reference CRS is {ref_crs}."
+        )
+
     # --- PDAL pipeline definition ---
     pipeline_dict = {
         "pipeline": [
@@ -1124,7 +1131,7 @@ def plot_coregistration(config: Config) -> None:
 
     if symlinks_dir is not None and raw_dems_dir is not None:
         directories = list(Path(symlinks_dir).iterdir()) + [Path(raw_dems_dir), coreg_dems_dir]
-        viz.visualize_files_presence_map(directories, config.plot_dir / "submissions_presence_map.png")
+        viz.visualize_files_presence_map(directories, config.plot_dir / "files_presence_map.png")
 
 
 def plot_ddems(config: Config) -> None:

--- a/src/history/postprocessing/pipeline.py
+++ b/src/history/postprocessing/pipeline.py
@@ -30,6 +30,7 @@ import zipfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Iterable
+import os
 
 import geoutils as gu
 from history.postprocessing.config import Config
@@ -649,8 +650,11 @@ def create_std_dem(
         return
 
     if is_existing_std_dem(dem_files, output_path, metadata_key) and not overwrite:
-        logger.info(f"Skip {output_path.name}: output already exists.")
-        return
+        all_input_mtimes = [os.path.getmtime(fname) for fname in list(dem_files)]
+        output_mtime = os.path.getmtime(output_path)
+        if output_mtime > np.max(all_input_mtimes):
+            logger.info(f"Skip {output_path.name}: output already exists.")
+            return
 
     # first open the first raster of the list to have a reference profile
     with rasterio.open(dem_files[0]) as src_ref:
@@ -1217,6 +1221,7 @@ def plot_ddems(config: Config) -> None:
     viz.barplot_var(df, config.plot_dir / "nmad_after_coregistration.png", "ddem_after_nmad", "NMAD of Altitude differences with ref DEM after coregistration by code")
 
     for (site, dataset), group in df.groupby(["site", "dataset"]):
+        logger.debug(f"Plotting **** {site} - {dataset} ****")
         sub_dir = config.plot_dir / f"{site}_{dataset}"
         viz.generate_plot_nmad_before_vs_after(group, sub_dir / "nmad_before_vs_after_coregistration.png", f"({site} {dataset}) NMAD of DEM differences before vs after coregistration")
         viz.generate_coregistration_individual_plots(group, sub_dir / "coregistrations", config.overwrite)

--- a/src/history/postprocessing/pipeline.py
+++ b/src/history/postprocessing/pipeline.py
@@ -88,14 +88,9 @@ def uncompress_all_submissions(
     input_dir = Path(input_dir)
     output_dir = Path(output_dir)
 
-    supported_extensions = [".zip", ".7z", ".tgz", ".tar.gz", ".tar.bz2", ".tar.xz"]
-
-    archives = [
-        (fp, output_dir / fp.name[: -len(ext)]) for ext in supported_extensions for fp in input_dir.glob(f"*{ext}")
-    ]
-
     args_list = []
-    for input_path, output_path in archives:
+    for input_path in input_dir.iterdir():
+        output_path = output_dir / input_path.name.split(".")[0]
         if output_path.exists() and not overwrite:
             logger.info(f"Skipping extraction (folder exists): {output_path}")
             continue
@@ -938,6 +933,10 @@ def extract_archive(archive_path: Path | str, output_dir: Path | str, flatten_ne
     archive_path = Path(archive_path)
     output_dir = Path(output_dir)
 
+    # Check format before touching the filesystem so failed extractions leave no empty folder
+    if archive_path.suffix not in [".zip", ".7z", ".tar", ".tgz", ".gz", ".bz2", ".xz"]:
+        raise ValueError(f"Extraction for this type not implemented: {archive_path.suffix}")
+
     # overwrite if existing
     if output_dir.exists():
         shutil.rmtree(output_dir)
@@ -954,8 +953,6 @@ def extract_archive(archive_path: Path | str, output_dir: Path | str, flatten_ne
     elif archive_path.suffix in [".tar", ".tgz", ".gz", ".bz2", ".xz"]:
         with tarfile.open(archive_path, "r:*") as tf:
             tf.extractall(output_dir)
-    else:
-        raise ValueError(f"Extraction for this type not implemented: {archive_path.suffix}")
 
     # remove macOS metadata if exists
     macosx_dir = output_dir / "__MACOSX"

--- a/src/history/postprocessing/pipeline.py
+++ b/src/history/postprocessing/pipeline.py
@@ -21,7 +21,6 @@ libraries, ensuring consistent handling of CRS, raster grids, and metadata.
 
 import json
 import logging
-import re
 import shutil
 import subprocess
 import sys
@@ -31,7 +30,6 @@ import zipfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Iterable
-from collections import Counter
 
 import geoutils as gu
 import humanize
@@ -49,7 +47,7 @@ from tqdm import tqdm
 import history.postprocessing.io as io
 import history.postprocessing.statistics as stats
 import history.postprocessing.visualization as viz
-from history.postprocessing.io import FilenameParseError, ReferencesData, parse_filename
+from history.postprocessing.io import ReferencesData, parse_filename
 
 logger = logging.getLogger(__name__)
 
@@ -120,182 +118,92 @@ def uncompress_all_submissions(
                 continue
 
 
-def index_submissions_and_link_files(input_dir: str | Path, output_dir: str, overwrite: bool = False) -> None:
-    """
-    Index all submissions contained in the input directory, extract metadata from
-    filenames, and create a standardized directory of symbolic links pointing to
-    the detected files.
+def create_symlinks(df: pd.DataFrame, output_dir: str | Path, overwrite: bool = False) -> None:
+    """Create typed symlink directories from a scanned submissions DataFrame.
 
-    This function scans each subdirectory of `input_dir`, identifies relevant data
-    files based on predefined regex patterns (mandatory and optional), extracts
-    metadata using `parse_filename()`, and stores the results in an internal
-    DataFrame indexed by submission code. For each detected file, a corresponding
-    symbolic link is created in a structured output directory. Missing mandatory
-    files are reported but do not stop the processing.
-
-    If `overwrite` is True, all existing symlink directories inside the output
-    directory are removed before any new links are created.
+    Each file column in *df* is mapped to a subdirectory under *output_dir*
+    (e.g. ``dense_pointcloud_file`` → ``dense_pointclouds/``). Existing symlinks at
+    the target path are replaced without following them (avoids permission errors on
+    inaccessible mounts). Non-symlink files at the target path are left untouched.
 
     Parameters
     ----------
-    input_dir : str or Path
-        Directory containing submission subfolders to index. Each subfolder is
-        expected to contain files with names that match the configured patterns.
-    output_dir : str or Path
-        Target directory in which symbolic links will be created, organized by
-        file type.
-    overwrite : bool, optional
-        If True, existing symlink directories within `output_dir` are removed
-        before new links are generated. Default is False.
-
-    Notes
-    -----
-    - Mandatory files are defined by regex patterns such as point cloud, intrinsic,
-      and extrinsic calibration files. Their absence is logged as a warning.
-    - File metadata (extracted by `parse_filename`) is added to the indexing
-      DataFrame prior to link creation.
-    - Symlinks are always recreated: existing links or files at the target
-      location are removed before new ones are written.
+    df:
+        DataFrame returned by :func:`io.scan_submissions`, indexed by submission code.
+    output_dir:
+        Root directory where symlink subdirectories will be created.
+    overwrite:
+        If True, *output_dir* is deleted entirely before creating new links.
     """
-    input_dir = Path(input_dir)
     output_dir = Path(output_dir)
 
-    # if overwrite remove each symlinks directory
-    if overwrite:
-        for sub_dir in output_dir.sub_dirs.values():
-            if sub_dir.symlinks_dir.base_dir.exists():
-                shutil.rmtree(sub_dir.symlinks_dir.base_dir)
+    if overwrite and output_dir.exists():
+        shutil.rmtree(output_dir)
 
-    # Define regex patterns mapping to dataframe column names
-    mandatory_patterns = {
-        "dense_pointcloud_file": r"_dense_pointcloud\.(las|laz)$",
-        "sparse_pointcloud_file": r"_sparse_pointcloud\.(las|laz)$",
-        "extrinsics_file": r"_extrinsics\.csv$",
-        "intrinsics_file": r"_intrinsics\.csv$",
-    }
-    optional_patterns = {"dem_file": r".*dem.*\.tif$", "orthoimage_file": r".*orthoimage.*\.tif$"}
-
-    patterns = {**mandatory_patterns, **optional_patterns}
-
-    df = pd.DataFrame()
-    df.index.name = "code"
-    for subdir in input_dir.iterdir():
-        if not subdir.is_dir():
-            continue
-
-        all_files = list(subdir.rglob("*"))
-
-        for file in all_files:
-            try:
-                code, metadatas = parse_filename(file)
-            except FilenameParseError as e:
-                relevant_extensions = {".las", ".laz", ".tif", ".csv"}
-                if file.suffix.lower() in relevant_extensions:
-                    logger.warning(f"Cannot parse filename: {e}")
-                else:
-                    logger.debug(f"Skipping non-submission file: {e}")
+    for _code, row in df.iterrows():
+        for col, subdir_name in io._FILE_COL_TO_SUBDIR.items():
+            if col not in row or pd.isna(row[col]):
                 continue
-            
-            for column, pattern in patterns.items():
-                if re.search(pattern, file.name, re.IGNORECASE):
-                    df.at[code, "submission"] = subdir.name
-                    for k, v in metadatas.items():
-                        df.at[code, k] = v
-                    df.at[code, column] = str(file)
+            link = output_dir / subdir_name / Path(row[col]).name
+            link.parent.mkdir(exist_ok=True, parents=True)
+            if link.is_symlink():
+                link.unlink()
+            link.symlink_to(row[col])
 
-                    break  # Stop at first match
 
-    for code, row in df.iterrows():
-        missing_files = [c for c in mandatory_patterns if pd.isna(row[c])]
-        if missing_files:
-            logger.warning(f"{code} - Missing the following mandatory file(s): {missing_files}")
-        for colname in patterns:
-            if not pd.isna(row[colname]):
-                sub_dirname = colname.replace("_file", "")
-                if not sub_dirname.endswith("s"):
-                    sub_dirname += "s"
+def index_submissions_and_link_files(input_dir: str | Path, output_dir: str | Path, overwrite: bool = False) -> None:
+    """Scan, validate, and create symlinks for all submissions in *input_dir*.
 
-                link = output_dir / sub_dirname / Path(row[colname]).name
-                link.parent.mkdir(exist_ok=True, parents=True)
-
-                # Remove existing link if it already exists
-                if link.exists() or link.is_symlink():
-                    link.unlink()
-                link.symlink_to(row[colname])
+    Convenience wrapper combining :func:`io.scan_submissions`,
+    :func:`io.validate_submissions`, and :func:`create_symlinks`.
+    Kept for backwards compatibility with existing notebooks.
+    """
+    df = io.scan_submissions(input_dir)
+    io.validate_submissions(df)
+    create_symlinks(df, output_dir, overwrite=overwrite)
 
 
 def check_planned_submissions(
-    pointcloud_files: list[str | Path],
+    submission_codes: list[str],
     planned_outfile: str | Path,
-):
-    """
-    Check received/processed submissions against planned submissions filled in shared Google sheet.
+) -> None:
+    """Compare received submission codes against the planned list from the shared Google Sheet.
 
-    Google sheet file is downloaded and converted to CSV with gdown.
-    Submitted experiment codes are extracted from point cloud filenames and compared to planned results.
+    Downloads and updates the planned-submissions CSV at *planned_outfile*, then logs
+    which planned submissions are missing and which received submissions were unplanned.
 
     Parameters
     ----------
-    pointcloud_files : list[str | Path]
-        List of extracted point cloud file paths.
-    planned_outfile : str or Path
-        Location where to save the planned CSV file, that is downloaded from GDrive and updated.
+    submission_codes:
+        Experiment codes to compare (e.g. ``df.index.tolist()`` from :func:`io.scan_submissions`).
+    planned_outfile:
+        Path where the downloaded/updated planned-submissions CSV is saved.
     """
-    pointcloud_files: list[Path] = [Path(f) for f in pointcloud_files]
     planned_outfile = Path(planned_outfile)
-
-    # Download planned submissions from shared sheet
     planned_df = io.download_planned_submissions(planned_outfile)
 
-    # Extract experiment codes of processed point clouds
-    processed_success_codes = []
-    processed_fail_codes = []
-    for file in pointcloud_files:
-        try:
-            code, metadatas = parse_filename(file)
-            processed_success_codes.append(code)
-        except Exception as e:
-            logger.error(f"Error processing {file.name}: {e}")
-            # Try to extract code even if not matching expected pattern
-            code = "_".join(file.stem.split("_")[:-2])
-            processed_fail_codes.append(code)
-            continue
-
-    # Check processed codes are unique
-    all_codes = processed_success_codes + processed_fail_codes
-    counts = Counter(all_codes)
-    non_uniques = [x for x in all_codes if counts[x] > 1]
-    if len(non_uniques) > 0:
-        logger.warning(f"Found {len(non_uniques)} non unique codes:")
-        for code in non_uniques:
-            logger.warning(f"\t{code}")
-
-    # Find received, successully processed and unplanned submissions
-    set_processed = set(processed_success_codes)
+    set_received = set(submission_codes)
     set_planned = set(planned_df["Submission code"])
 
-    received = planned_df["Submission code"].map(lambda x: x in all_codes)
-    planned_df["received"] = received
+    planned_df["received"] = planned_df["Submission code"].map(lambda x: x in set_received)
 
-    processed = planned_df["Submission code"].map(lambda x: x in processed_success_codes)
-    planned_df["processed"] = processed
+    unsubmitted = planned_df.loc[~planned_df["received"], "Submission code"].tolist()
+    unplanned = sorted(set_received - set_planned)
 
-    unplanned = set_processed - set_planned
+    logger.info(f"{len(planned_df) - len(unsubmitted)}/{len(planned_df)} planned submissions received")
 
-    print(f"Found {len(planned_df[~planned_df['received']])} unsubmitted results")
-    for code in planned_df[~planned_df['received']]["Submission code"]:
-        print(f"\t{code}")
+    if unsubmitted:
+        logger.warning(f"{len(unsubmitted)} planned submissions not yet received:")
+        for code in sorted(unsubmitted):
+            logger.warning(f"  {code}")
 
-    print(f"Found {len(unplanned)} unplanned results")
-    for code in sorted(unplanned):
-        print(f"\t{code}")
+    if unplanned:
+        logger.warning(f"{len(unplanned)} unplanned submissions received:")
+        for code in unplanned:
+            logger.warning(f"  {code}")
 
-    # print("\nTo update 'received' column on sheet, copy/paste below:")
-    # for res in planned_df["received"]:
-    #     print(f"{res}")
-    
     planned_df.to_csv(planned_outfile)
-    print(f"Updated planned submissions saved to {planned_outfile}. \nOpen and copy in VSCode with command 'edit csv'.")
+    logger.info(f"Updated planned submissions saved to {planned_outfile}.")
 
 def process_pointclouds_to_dems(
     pointcloud_files: list[str | Path],

--- a/src/history/postprocessing/pipeline.py
+++ b/src/history/postprocessing/pipeline.py
@@ -91,6 +91,10 @@ def uncompress_all_submissions(
 
     args_list = []
     for input_path in input_dir.iterdir():
+        if input_path.suffix in [".docx", ".pdf", ".odt"]:
+            logger.debug(f"Ignoring file {input_path} which is not an archive")
+            continue
+
         output_path = output_dir / input_path.name.split(".")[0]
         if output_path.exists() and not overwrite:
             logger.info(f"Skipping extraction (folder exists): {output_path}")
@@ -320,23 +324,39 @@ def process_pointclouds_to_dems(
             logger.error(f"Error processing {file.name}: {e}")
             continue
 
-    if not args_dict:
-        return
+    if len(args_dict) > 0:
 
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = {
-            executor.submit(convert_pointcloud_to_dem, *args, pdal_exec_path=pdal_exec_path, dry_run=dry_run): code
-            for code, args in args_dict.items()
-        }
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {
+                executor.submit(convert_pointcloud_to_dem, *args, pdal_exec_path=pdal_exec_path, dry_run=dry_run): code
+                for code, args in args_dict.items()
+            }
 
-        # Wait for all point2dem tasks to finish
-        for fut in tqdm(as_completed(futures), total=len(futures), desc="point2dem"):
-            code = futures[fut]
-            try:
-                fut.result()
-            except Exception as e:
-                logger.error(f"Point2dem error for {code}: {e}")
-                continue
+            # Wait for all point2dem tasks to finish
+            for fut in tqdm(as_completed(futures), total=len(futures), desc="point2dem"):
+                code = futures[fut]
+                try:
+                    fut.result()
+                except Exception as e:
+                    logger.error(f"Point2dem error for {code}: {e}")
+                    continue
+
+    # Check that no results from deleted submissions exist
+    raw_dem_files = list(output_directory.glob("*-DEM.tif"))
+    dem_prefixes = [f.stem[:-4] for f in raw_dem_files]
+    pc_prefixes = [f.stem[:-17] for f in pointcloud_files]
+    if len(dem_prefixes) != len(pc_prefixes):
+        unexpected_exp = list(set(dem_prefixes) - set(pc_prefixes))
+        unexpected_str = ", ".join(list(unexpected_exp))
+
+        logger.warning(f"Found the following experiments in the raw DEM folder: {unexpected_str}")
+        logger.warning("Consider deleting the following files:")
+
+        for code in unexpected_exp:
+            found_files = list(output_directory.parent.glob(f"**/*{code}*"))
+            print("command: rm " + str(output_directory.parent) + f"/**/*{code}*")
+            for f in found_files:
+                print(f)
 
 
 def add_provided_dems(

--- a/src/history/postprocessing/sankey.py
+++ b/src/history/postprocessing/sankey.py
@@ -1,0 +1,404 @@
+import pandas as pd
+import plotly.graph_objects as go
+import numpy as np
+from typing import List, Tuple, Dict, Optional
+
+
+# ---------- Utilities ----------
+
+def hex_to_rgba(hex_color: str, alpha: float = 0.5) -> str:
+    """
+    Convert HEX color to RGBA string, with default 50% transparency.
+
+    :param hex_color: Color in HEX format (e.g. "#FF5733")
+    :type hex_color: str
+    :param alpha: Transparency value between 0 and 1
+    :type alpha: float
+    :return: RGBA color string
+    :rtype: str
+    """
+    hex_color = hex_color.lstrip("#")
+    r, g, b = tuple(int(hex_color[i:i+2], 16) for i in (0, 2, 4))
+    return f"rgba({r},{g},{b},{alpha})"
+
+# -- Set of palettes, mostly from Seaborn --
+
+# Seaborn colorblind palette
+colorblind=[
+    "#0173B2", "#DE8F05", "#029E73", "#D55E00", "#CC78BC",
+    "#CA9161", "#FBAFE4", "#949494", "#ECE133", "#56B4E9"
+    ]
+
+# Same as previous, with gray removed, for edges only
+colorblind_nogrey = [
+    "#0173B2", "#DE8F05", "#029E73", "#D55E00", "#CC78BC",
+    "#CA9161", "#FBAFE4", "#ECE133", "#56B4E9"
+]
+
+# Seaborn deep palette
+deep = [
+    "#4C72B0", "#DD8452", "#55A868", "#C44E52", "#8172B3",
+    "#937860", "#DA8BC3", "#8C8C8C", "#CCB974", "#64B5CD"
+    ]
+
+# Custom palette
+palette_custom = [
+    "#4C78A8", "#F58518", "#E45756", "#72B7B2",
+    "#54A24B", "#EECA3B", "#B279A2", "#FF9DA6"
+]
+
+light_grey = "#B0B0B0"
+        
+# ---------- Core builders ----------
+
+def build_nodes(
+    df: pd.DataFrame,
+    columns: List[str],
+    palette: List[str],
+    edge_color: Tuple[str, None] = None,
+    force_color: dict = {},
+    alpha: float = 0.5
+) -> Tuple[List[str], Dict[str, int], List[str]]:
+    """
+    Build Sankey nodes (labels, mapping, colors).
+
+    First and last column nodes are colored grey.
+
+    :param df: Input dataframe
+    :type df: pd.DataFrame
+    :param columns: Ordered list of columns defining the flow
+    :type columns: List[str]
+    :param palette: List of HEX colors for intermediate nodes
+    :type palette: List[str]
+    :param edge_color: HEX color for first and last columns
+    :type edge_color: str
+    :param alpha: Transparency for node colors
+    :type alpha: float
+    :return: Tuple of labels, label-to-index mapping, node colors
+    :rtype: Tuple[List[str], Dict[str, int], List[str]]
+    """
+    #labels = pd.unique(df[columns].values.ravel())
+    labels = []
+    for col in columns:
+        labels.extend(df[col].sort_values().unique())
+    labels = np.array(labels)
+    label_dict = {label: i for i, label in enumerate(labels)}
+
+    # Map label → column index
+    label_to_col: Dict[str, int] = {}
+    for col_idx, col in enumerate(columns):
+        for val in df[col].unique():
+            label_to_col[val] = col_idx
+
+    n_cols = len(columns)
+    node_colors: List[str] = []
+    for i, label in enumerate(labels):
+        print(label)
+        col_idx = label_to_col[label]
+
+        if edge_color is not None:
+            if col_idx == 0 or col_idx == n_cols - 1:
+                color = hex_to_rgba(edge_color, alpha)
+        else:
+            if columns[col_idx] in force_color.keys():
+                color = hex_to_rgba(force_color[columns[col_idx]], alpha)
+            else:
+                base_color = palette[i % len(palette)]
+                color = hex_to_rgba(base_color, alpha)
+
+        node_colors.append(color)
+
+    return labels.tolist(), label_dict, node_colors
+
+
+def build_links(
+    df: pd.DataFrame,
+    columns: List[str],
+    label_dict: Dict[str, int]
+) -> Tuple[List[int], List[int], List[int]]:
+    """
+    Build Sankey links between consecutive columns.
+
+    :param df: Input dataframe
+    :type df: pd.DataFrame
+    :param columns: Ordered list of columns
+    :type columns: List[str]
+    :param label_dict: Mapping from label to node index
+    :type label_dict: Dict[str, int]
+    :return: source indices, target indices, values
+    :rtype: Tuple[List[int], List[int], List[int]]
+    """
+    all_links = []
+
+    for i in range(len(columns) - 1):
+        src_col = columns[i]
+        tgt_col = columns[i + 1]
+
+        grouped = (
+            df.groupby([src_col, tgt_col])
+            .size()
+            .reset_index(name="value")
+        )
+        grouped.columns = ["source", "target", "value"]
+        all_links.append(grouped)
+
+    all_links_df = pd.concat(all_links, ignore_index=True)
+
+    source = all_links_df["source"].map(label_dict).astype(int).tolist()
+    target = all_links_df["target"].map(label_dict).astype(int).astype(int).tolist()
+    value = all_links_df["value"].astype(int).tolist()
+
+    return source, target, value
+
+
+def compute_nodes_totals(
+    source: List[int],
+    target: List[int],
+    value: List[int],
+    n_nodes: int
+) -> List[int]:
+    """
+    Compute max in and out flow totals per node.
+
+    :param source: Source node indices
+    :type source: List[int]
+    :param source: Target node indices
+    :type source: List[int]
+    :param value: Flow values
+    :type value: List[int]
+    :param n_nodes: Number of nodes
+    :type n_nodes: int
+    :return: Outgoing totals per node
+    :rtype: List[int]
+    """
+    totals_in = [0] * n_nodes
+    totals_out = [0] * n_nodes
+    
+    for s, t, v in zip(source, target, value):
+        totals_out[s] += v
+        totals_in[t] += v
+
+    totals = np.maximum(totals_in, totals_out)
+    
+    return totals
+
+
+def format_labels(
+    labels: List[str],
+    totals: List[int],
+    hide_zero: bool = True
+) -> List[str]:
+    """
+    Append totals to labels.
+
+    :param labels: Node labels
+    :type labels: List[str]
+    :param totals: Outgoing totals per node
+    :type totals: List[int]
+    :param hide_zero: Hide nodes with zero outgoing flow
+    :type hide_zero: bool
+    :return: Formatted labels
+    :rtype: List[str]
+    """
+    formatted = []
+    for i, label in enumerate(labels):
+        if hide_zero and totals[i] == 0:
+            formatted.append(str(label))
+        else:
+            formatted.append(f"{label} ({totals[i]})")
+    return formatted
+
+
+def build_sankey_figure(
+    labels: List[str],
+    node_colors: List[str],
+    source: List[int],
+    target: List[int],
+    value: List[int],
+    column_titles: List[str],
+    title: str = "Sankey Diagram",
+    font_size: int = 20,
+) -> go.Figure:
+    """
+    Create Plotly Sankey figure.
+
+    :param labels: Node labels
+    :type labels: List[str]
+    :param node_colors: Node colors
+    :type node_colors: List[str]
+    :param source: Source indices
+    :type source: List[int]
+    :param target: Target indices
+    :type target: List[int]
+    :param value: Flow values
+    :type value: List[int]
+    :param column_titles: Column names for annotations
+    :type column_titles: List[str]
+    :param title: Figure title
+    :type title: str
+    :return: Plotly figure
+    :rtype: go.Figure
+    """
+    link_colors = [node_colors[s] for s in source]
+
+    fig = go.Figure(data=[go.Sankey(
+        arrangement="snap",
+        node=dict(
+            pad=20,
+            thickness=25,
+            line=dict(color="black", width=0.5),
+            label=labels,
+            color=node_colors
+        ),
+        link=dict(
+            source=source,
+            target=target,
+            value=value,
+            color=link_colors
+        )
+    )])
+
+    # Column annotations
+    annotations = []
+    n = len(column_titles)
+    for i, col in enumerate(column_titles):
+        annotations.append(
+            dict(
+                x=i / (n - 1) if n > 1 else 0.5,
+                y=1.05,
+                text=col,
+                showarrow=False,
+                font=dict(size=font_size)
+            )
+        )
+
+    fig.update_layout(
+        title_text=title,
+        font=dict(size=font_size),
+        annotations=annotations
+    )
+
+    return fig
+
+
+def show_palette(palette, width=0.5):
+    """
+    A small utility function to display a HEX palette with plotly 
+    """
+    fig = go.Figure()
+
+    for i, color in enumerate(palette):
+        fig.add_shape(
+            type="rect",
+            x0=i*width, x1=(i+1)*width,
+            y0=0, y1=1,
+            fillcolor=color,
+            line=dict(width=0)
+        )
+
+        fig.add_annotation(
+            x=(i+0.5)*width,
+            y=-0.2,
+            text=color,
+            showarrow=False,
+            font=dict(size=12)
+        )
+
+    fig.update_xaxes(visible=False)
+    fig.update_yaxes(visible=False)
+
+    fig.update_layout(
+        title="Color Palette",
+        height=200,
+        margin=dict(t=40, b=40, l=20, r=20)
+    )
+
+    fig.show()
+
+
+# ---------- Main API ----------
+
+def dataframe_to_sankey(
+    df: pd.DataFrame,
+    columns: List[str],
+    output_file: str = "sankey.png",
+    columns_label: Optional[List[str]] = None,
+    palette: Optional[List[str]] = None,
+    edge_color: str = None,
+    force_color: dict = {},
+    alpha: float = 0.5,
+    title: str = "Sankey Diagram",
+    font_size: int = 20,
+) -> go.Figure:
+    """
+    Convert a pandas DataFrame into a Sankey diagram and save as PNG.
+
+    :param df: Input dataframe
+    :type df: pd.DataFrame
+    :param columns: Ordered list of columns defining the flow
+    :type columns: List[str]
+    :param output_file: Output PNG file path
+    :type output_file: str
+    :param columns_label: Column labels to be used for the plot
+    :type columns_label: List[str]
+    :param palette: List of HEX colors for intermediate nodes
+    :type palette: Optional[List[str]]
+    :param edge_color: HEX color for first and last column nodes
+    :type edge_color: str
+    :param alpha: Transparency for nodes and links
+    :type alpha: float
+    :param title: Figure title
+    :type title: str
+    :return: Plotly Sankey figure
+    :rtype: go.Figure
+    """
+    if palette is None:
+        # Defaults to Seaborn colorblind palette, with gray removed, for edges only
+        palette = colorblind_nogrey
+
+    df_clean = df[columns].dropna()
+    labels, label_dict, node_colors = build_nodes(
+        df_clean, 
+        columns,
+        palette,
+        edge_color=edge_color,
+        force_color=force_color,
+        alpha=alpha,
+    )
+
+    source, target, value = build_links(df_clean, columns, label_dict)
+
+    totals = compute_nodes_totals(source, target, value, len(labels))
+    formatted_labels = format_labels(labels, totals)
+
+    if columns_label is None:
+        columns_label = columns
+
+    fig = build_sankey_figure(
+        formatted_labels,
+        node_colors,
+        source,
+        target,
+        value,
+        columns_label,
+        title=title,
+        font_size=font_size,
+    )
+
+    # Save PNG (requires kaleido)
+    fig.write_image(output_file, width=1200, height=700, scale=2)
+
+    return fig
+
+if __name__ == "__main__":
+    
+    df = pd.read_csv("test_file.csv")
+
+    fig = dataframe_to_sankey(
+        df,
+        columns=["dataset", "georef", "mtp_adjustment", "software"],
+        output_file="sankey_diagram3.png",
+        title="Sankey diagram"
+    )
+
+    fig.show()

--- a/src/history/postprocessing/visualization.py
+++ b/src/history/postprocessing/visualization.py
@@ -4,6 +4,7 @@ Contains functions to generate post-processing Visualization
 
 import math
 from contextlib import contextmanager
+import logging
 from pathlib import Path
 from typing import Generator
 
@@ -19,6 +20,8 @@ from matplotlib.patches import Patch
 from rasterio.enums import Resampling
 
 from history.postprocessing.io import parse_filename
+
+logger = logging.getLogger(__name__)
 
 #######################################################################################################################
 ##                                                  MOSAIC VISUALIZATION
@@ -118,11 +121,15 @@ def generate_ddems_mosaic(
     """
     with _generate_mosaic_figure_and_axes(len(ddem_files_dict), output_path) as (fig, axes):
         for i, (subtitle, file) in enumerate(ddem_files_dict.items()):
-            dem = _read_raster_with_max_size(file)
-            dem = np.clip(dem, vmin, vmax)
+            try:
+                dem = _read_raster_with_max_size(file)
+                dem = np.clip(dem, vmin, vmax)
 
-            axes[i].imshow(dem, cmap="coolwarm", vmin=vmin, vmax=vmax)
-            axes[i].set_title(subtitle)
+                axes[i].imshow(dem, cmap="coolwarm", vmin=vmin, vmax=vmax)
+                axes[i].set_title(subtitle)
+            except Exception as e:
+                logger.error(f"Issue plotting file {file}: {e}")
+                continue
 
         # add the global color bar
         cbar = fig.colorbar(

--- a/src/history/postprocessing/visualization.py
+++ b/src/history/postprocessing/visualization.py
@@ -168,7 +168,7 @@ def generate_slopes_mosaic(
     dem_files_dict: dict[str, list[str | Path]],
     output_path: str | Path,
     vmin: float = 0,
-    vmax: float = 15,
+    vmax: float = 40,
     title: str = "",
     overwrite: bool = False,
 ) -> None:

--- a/src/history/postprocessing/visualization.py
+++ b/src/history/postprocessing/visualization.py
@@ -79,7 +79,7 @@ def generate_dems_mosaic(
             return
 
     with _generate_mosaic_figure_and_axes(len(dem_files_dict), output_path) as (fig, axes):
-        for i, (subtitle, file) in enumerate(dem_files_dict.items()):
+        for i, (subtitle, file) in enumerate(sorted(dem_files_dict.items())):
             dem = _read_raster_with_max_size(file)
 
             axes[i].imshow(dem, cmap="terrain", vmin=vmin, vmax=vmax)
@@ -143,7 +143,7 @@ def generate_ddems_mosaic(
             return
         
     with _generate_mosaic_figure_and_axes(len(ddem_files_dict), output_path) as (fig, axes):
-        for i, (subtitle, file) in enumerate(ddem_files_dict.items()):
+        for i, (subtitle, file) in enumerate(sorted(ddem_files_dict.items())):
             try:
                 dem = _read_raster_with_max_size(file)
                 dem = np.clip(dem, vmin, vmax)
@@ -213,7 +213,7 @@ def generate_slopes_mosaic(
             return
 
     with _generate_mosaic_figure_and_axes(len(dem_files_dict), output_path) as (fig, axes):
-        for i, (subtitle, file) in enumerate(dem_files_dict.items()):
+        for i, (subtitle, file) in enumerate(sorted(dem_files_dict.items())):
             dem = _read_raster_with_max_size(file)
 
             with rasterio.open(file) as src:
@@ -289,7 +289,7 @@ def generate_hillshades_mosaic(
             return
 
     with _generate_mosaic_figure_and_axes(len(dem_files_dict), output_path) as (fig, axes):
-        for i, (subtitle, file) in enumerate(dem_files_dict.items()):
+        for i, (subtitle, file) in enumerate(sorted(dem_files_dict.items())):
             dem = _read_raster_with_max_size(file)
 
             with rasterio.open(file) as src:

--- a/src/history/postprocessing/visualization.py
+++ b/src/history/postprocessing/visualization.py
@@ -694,26 +694,175 @@ def visualize_files_presence_map(directories: list[str | Path], output_path: str
     ----------
     directories : list[str | Path]
         List of directories to scan for files. Only files with parsable codes are considered.
-
-    Returns
-    -------
-    None
-        The function generates a plot showing the presence/absence map; it does not return a value.
+    output_path : str or Path or None, optional
+        If provided the plot is saved there; otherwise it is displayed interactively.
     """
     directories: list[Path] = [Path(d) for d in directories]
-    df = pd.DataFrame()
-    df.index.name = "code"
+    rows: dict[str, dict] = {}
 
     for directory in directories:
         if directory.is_dir():
             for file in directory.iterdir():
                 if file.is_file():
-                    code, _ = parse_filename(file)
+                    code, metadata = parse_filename(file)
+                    row = rows.setdefault(code, {"site": metadata.get("site", ""), "dataset": metadata.get("dataset", "")})
+                    row[directory.name] = True
 
-                    df.at[code, directory.name] = True
+    df = pd.DataFrame.from_dict(rows, orient="index")
+    df.index.name = "code"
+    col_labels = [c for c in df.columns if c not in ("site", "dataset")]
+    df[col_labels] = df[col_labels].astype(pd.BooleanDtype()).fillna(False)
 
-    df = df.astype(pd.BooleanDtype()).fillna(False).sort_index()
-    _plot_boolean_df(df, cell_height=0.2, output_path=output_path, show=(output_path is None))
+    group_cols = [c for c in ("site", "dataset") if c in df.columns and df[c].notna().any()]
+    groups = [(key, grp[col_labels].sort_index()) for key, grp in df.groupby(group_cols, sort=True)] if group_cols else [("all", df[col_labels].sort_index())]
+
+    n_groups = len(groups)
+    ncols_fig = min(3, n_groups)
+    nrows_fig = math.ceil(n_groups / ncols_fig)
+
+    cell_w, cell_h = 1.2, 0.28
+    subplot_w = max(3.5, len(col_labels) * cell_w + 1.5)
+    subplot_h = max(2.0, max(len(grp) for _, grp in groups) * cell_h + 1.2)
+    fig, axes = plt.subplots(nrows_fig, ncols_fig, figsize=(ncols_fig * subplot_w + 1.0, nrows_fig * subplot_h + 0.6), squeeze=False)
+    for ax in axes.ravel():
+        ax.axis("off")
+
+    for idx, (key, grp) in enumerate(groups):
+        ax = axes[idx // ncols_fig][idx % ncols_fig]
+        ax.axis("on")
+        _plot_boolean_df(grp, ax=ax, title=" / ".join(key) if isinstance(key, tuple) else str(key))
+
+    fig.suptitle("Submission file presence", fontsize=13, weight="bold", y=1.01)
+    fig.tight_layout()
+
+    if output_path:
+        plt.savefig(output_path, bbox_inches="tight")
+
+    if output_path is None:
+        plt.show()
+    else:
+        plt.close()
+
+
+def visualize_files_size_map(df: pd.DataFrame, output_path: str | Path | None = None) -> None:
+    """
+    Create a visual file-size matrix for submission files.
+
+    Rows are submission codes; columns are the file-type columns recognised by
+    ``scan_submissions`` (dense/sparse point clouds, DEM, orthoimage).  Each cell
+    is colour-coded by size and annotated with a human-readable label (e.g. "1.2 GB").
+    Missing files are shown in light grey with a dash.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame returned by ``scan_submissions``, indexed by submission code.
+        Expected columns (subset): ``dense_pointcloud_file``, ``sparse_pointcloud_file``,
+        ``dem_file``, ``orthoimage_file``.
+    output_path : str or Path or None, optional
+        If provided the plot is saved there; otherwise it is displayed interactively.
+    """
+    _SIZE_COLS = {
+        "dense_pointcloud_file": "dense PC",
+        "sparse_pointcloud_file": "sparse PC",
+        "dem_file": "DEM",
+        "orthoimage_file": "ortho",
+    }
+
+    def _fmt_size(n_bytes: float) -> str:
+        for unit, threshold in (("GB", 1e9), ("MB", 1e6), ("KB", 1e3)):
+            if n_bytes >= threshold:
+                return f"{n_bytes / threshold:.1f} {unit}"
+        return f"{n_bytes:.0f} B"
+
+    def _fill_size_arrays(group_df: pd.DataFrame, cols: list[str]) -> tuple[np.ndarray, list[list[str]]]:
+        values = np.full((len(group_df), len(cols)), np.nan)
+        labels = [["—"] * len(cols) for _ in range(len(group_df))]
+        for j, col in enumerate(cols):
+            for i, (_, row) in enumerate(group_df.iterrows()):
+                path = row.get(col)
+                if pd.notna(path) and Path(path).is_file():
+                    size = Path(path).stat().st_size
+                    values[i, j] = size
+                    labels[i][j] = _fmt_size(size)
+        return values, labels
+
+    def _draw_matrix(ax: plt.Axes, group_df: pd.DataFrame, size_values: np.ndarray, text_labels: list, col_labels: list, title: str) -> None:
+        n_rows, n_cols = size_values.shape
+        cmap = plt.get_cmap("YlOrRd")
+        missing_color = np.array([0.827, 0.827, 0.827, 1.0])  # lightgrey
+
+        # Build an RGBA image where each column is normalised independently.
+        rgba = np.ones((n_rows, n_cols, 4))
+        for j in range(n_cols):
+            col_vals = size_values[:, j]
+            valid = col_vals[~np.isnan(col_vals)]
+            col_vmin = float(valid.min()) if len(valid) else 0.0
+            col_vmax = float(valid.max()) if len(valid) else 1.0
+            col_range = col_vmax - col_vmin if col_vmax != col_vmin else 1.0
+            for i in range(n_rows):
+                if np.isnan(col_vals[i]):
+                    rgba[i, j] = missing_color
+                else:
+                    rgba[i, j] = cmap((col_vals[i] - col_vmin) / col_range)
+
+        ax.imshow(rgba, aspect="auto", origin="lower", extent=(0, n_cols, 0, n_rows))
+        # Grid lines
+        for x in range(n_cols + 1):
+            ax.axvline(x, color="grey", linewidth=0.8)
+        for y in range(n_rows + 1):
+            ax.axhline(y, color="grey", linewidth=0.8)
+
+        for i in range(n_rows):
+            for j in range(n_cols):
+                ax.text(j + 0.5, i + 0.5, text_labels[i][j], ha="center", va="center", fontsize=7.5)
+        ax.set_xticks(np.arange(n_cols) + 0.5)
+        ax.set_yticks(np.arange(n_rows) + 0.5)
+        ax.set_xticklabels(col_labels, rotation=30, ha="right", fontsize=9)
+        ax.set_yticklabels(group_df.index, fontsize=8)
+        ax.set_title(title, fontsize=10, weight="bold")
+
+    present_cols = [c for c in _SIZE_COLS if c in df.columns]
+    col_labels = [_SIZE_COLS[c] for c in present_cols]
+
+    group_cols = [c for c in ("site", "dataset") if c in df.columns]
+    if group_cols:
+        groups = [(key, grp) for key, grp in df.groupby(group_cols, sort=True)]
+    else:
+        groups = [("all", df)]
+
+    n_groups = len(groups)
+    ncols_fig = min(3, n_groups)
+    nrows_fig = math.ceil(n_groups / ncols_fig)
+
+    # Each sub-table: width fixed by number of file columns; height by number of rows.
+    cell_w, cell_h = 1.4, 0.30
+    subplot_w = max(3.5, len(present_cols) * cell_w + 1.5)
+    subplot_h = max(2.0, max(len(grp) for _, grp in groups) * cell_h + 1.2)
+    fig_width = ncols_fig * subplot_w + 1.0
+    fig_height = nrows_fig * subplot_h + 0.6
+
+    fig, axes = plt.subplots(nrows_fig, ncols_fig, figsize=(fig_width, fig_height), squeeze=False)
+    for ax in axes.ravel():
+        ax.axis("off")
+
+    for idx, (key, grp) in enumerate(groups):
+        ax = axes[idx // ncols_fig][idx % ncols_fig]
+        ax.axis("on")
+        size_values, text_labels = _fill_size_arrays(grp, present_cols)
+        title = " / ".join(key) if isinstance(key, tuple) else str(key)
+        _draw_matrix(ax, grp, size_values, text_labels, col_labels, title)
+
+    fig.suptitle("Submission file sizes", fontsize=13, weight="bold", y=1.01)
+    fig.tight_layout()
+
+    if output_path:
+        plt.savefig(output_path, bbox_inches="tight")
+
+    if output_path is None:
+        plt.show()
+    else:
+        plt.close()
 
 
 def generate_coregistration_individual_plots(
@@ -828,67 +977,48 @@ def _plot_boolean_df(
     cell_height: float = 0.4,
     min_width: float = 6,
     min_height: float = 4,
+    ax: Axes | None = None,
 ) -> None:
     """
     Plot a boolean DataFrame as a black/white matrix using pcolormesh,
     with automatic figure size based on the DataFrame shape.
-
-    Parameters
-    ----------
-    df : pd.DataFrame
-        DataFrame containing only boolean values.
-    title : str, optional
-        Title of the plot.
-    output_path : str or None, optional
-        If provided, the plot is saved to the given file path.
-    show : bool, optional
-        Whether to display the plot.
-    cell_width : float, optional
-        Width (in inches) allocated per column.
-    cell_height : float, optional
-        Height (in inches) allocated per row.
-    min_width : float, optional
-        Minimum figure width in inches.
-    min_height : float, optional
-        Minimum figure height in inches.
+    If *ax* is provided, draws into that axes and skips figure creation/saving.
     """
-    # Convert boolean DataFrame to integer matrix (1=True, 0=False)
     matrix = df.astype(int).values
-
-    # Compute figure size based on DataFrame shape
     n_rows, n_cols = df.shape
-    fig_width = max(min_width, n_cols * cell_width)
-    fig_height = max(min_height, n_rows * cell_height)
 
-    fig, ax = plt.subplots(figsize=(fig_width, fig_height))
+    if ax is None:
+        fig_width = max(min_width, n_cols * cell_width)
+        fig_height = max(min_height, n_rows * cell_height)
+        fig, ax = plt.subplots(figsize=(fig_width, fig_height))
+        standalone = True
+    else:
+        fig = None
+        standalone = False
 
-    # Use a binary colormap for black/white representation
     cmap = plt.get_cmap("binary")
     ax.pcolormesh(matrix, cmap=cmap, edgecolors="grey", linewidth=1, shading="auto")
 
-    # Set tick positions
     ax.set_xticks(np.arange(n_cols) + 0.5)
     ax.set_yticks(np.arange(n_rows) + 0.5)
     ax.set_xticklabels(df.columns, rotation=30, ha="right", fontsize=9)
     ax.set_yticklabels(df.index, fontsize=9)
 
-    # Add visible grid
     ax.set_xticks(np.arange(n_cols), minor=True)
     ax.set_yticks(np.arange(n_rows), minor=True)
     ax.grid(which="minor", color="grey", linestyle="-", linewidth=0.8, alpha=0.7)
     ax.tick_params(which="minor", bottom=False, left=False)
 
-    # Title and layout
-    ax.set_title(title, fontsize=14, weight="bold")
-    fig.tight_layout()
+    ax.set_title(title, fontsize=10 if not standalone else 14, weight="bold")
 
-    if output_path:
-        plt.savefig(output_path)
-
-    if show:
-        plt.show()
-    else:
-        plt.close()
+    if standalone:
+        fig.tight_layout()
+        if output_path:
+            plt.savefig(output_path)
+        if show:
+            plt.show()
+        else:
+            plt.close()
 
 
 def _plot_grouped_boxplot(df: pd.DataFrame, category_col: str, hue_col: str, y_label: str = "", title: str = ""):

--- a/src/history/postprocessing/visualization.py
+++ b/src/history/postprocessing/visualization.py
@@ -681,7 +681,7 @@ def generate_landcover_grouped_boxplot_from_std_dems(std_landcover_df: pd.DataFr
 #######################################################################################################################
 
 
-def visualize_files_presence_map(directories: list[str | Path]) -> None:
+def visualize_files_presence_map(directories: list[str | Path], output_path: str | Path | None = None) -> None:
     """
     Create a visual presence/absence map of files across multiple directories.
 
@@ -713,7 +713,7 @@ def visualize_files_presence_map(directories: list[str | Path]) -> None:
                     df.at[code, directory.name] = True
 
     df = df.astype(pd.BooleanDtype()).fillna(False).sort_index()
-    _plot_boolean_df(df, cell_height=0.2)
+    _plot_boolean_df(df, cell_height=0.2, output_path=output_path, show=(output_path is None))
 
 
 def generate_coregistration_individual_plots(

--- a/src/history/postprocessing/visualization.py
+++ b/src/history/postprocessing/visualization.py
@@ -372,10 +372,13 @@ def barplot_var(global_df: pd.DataFrame, output_path: str | Path, colname: str, 
     - Each unique combination of `site` and `dataset` is treated as a separate color group.
     - The x-axis labels correspond to the DataFrame index, rotated for readability.
     """
-    inputs = global_df.file.values
-    if not overwrite and is_output_up_to_date(inputs, output_path):
-        logger.debug(f"File {output_path} is up to date -> skipping.")
-        return
+    file_cols = [c for c in global_df.columns if c == "file" or c.endswith("_file")]
+    inputs = pd.concat([global_df[c].dropna() for c in file_cols]).values if file_cols else None
+    if not overwrite:
+        check = is_output_up_to_date(inputs, output_path) if inputs is not None and len(inputs) > 0 else Path(output_path).exists()
+        if check:
+            logger.debug(f"File {output_path} is up to date -> skipping.")
+            return
 
     df = global_df.dropna(subset=[colname]).copy(True)
 
@@ -421,7 +424,7 @@ def barplot_var(global_df: pd.DataFrame, output_path: str | Path, colname: str, 
     fig.savefig(output_path)
 
 
-def generate_plot_coreg_shifts(df: pd.DataFrame, output_path: str | Path, title: str = "", overwrite: bool = False) -> None:
+def generate_plot_coreg_shifts(df: pd.DataFrame, output_path: str | Path, title: str = "", overwrite: bool = False, inputs=None) -> None:
     """
     Generate a bar plot of coregistration shifts (X, Y, Z) from a DataFrame and save it to a file.
 
@@ -448,9 +451,11 @@ def generate_plot_coreg_shifts(df: pd.DataFrame, output_path: str | Path, title:
     - Rows with NaN values in any of the shift columns are ignored.
     - Shifts are displayed in meters with labels above each bar.
     """
-    if not overwrite and Path(output_path).exists():
-        logger.debug(f"File {output_path} already exists -> skipping.")
-        return
+    if not overwrite:
+        check = is_output_up_to_date(inputs, output_path) if inputs is not None else Path(output_path).exists()
+        if check:
+            logger.debug(f"File {output_path} is up to date -> skipping.")
+            return
 
     colnames = ["coreg_shift_x", "coreg_shift_y", "coreg_shift_z"]
     dropped_df = (
@@ -499,9 +504,13 @@ def generate_plot_nmad_before_vs_after(df: pd.DataFrame, output_path: str | Path
     None
         The plot is saved to the specified path without returning a value.
     """
-    if not overwrite and Path(output_path).exists():
-        logger.debug(f"File {output_path} already exists -> skipping.")
-        return
+    if not overwrite:
+        file_cols = [c for c in ("ddem_before_file", "ddem_after_file") if c in df.columns]
+        inputs = pd.concat([df[c].dropna() for c in file_cols]).values if file_cols else None
+        check = is_output_up_to_date(inputs, output_path) if inputs is not None and len(inputs) > 0 else Path(output_path).exists()
+        if check:
+            logger.debug(f"File {output_path} is up to date -> skipping.")
+            return
 
     colnames = ["ddem_before_nmad", "ddem_after_nmad"]
     dropped_df = df.dropna(subset=colnames).sort_values(by="ddem_after_nmad")
@@ -527,7 +536,7 @@ def generate_plot_nmad_before_vs_after(df: pd.DataFrame, output_path: str | Path
 #######################################################################################################################
 
 
-def generate_landcover_grouped_boxplot(landcover_df: pd.DataFrame, output_path: str | Path, title: str = "", overwrite: bool = False) -> None:
+def generate_landcover_grouped_boxplot(landcover_df: pd.DataFrame, output_path: str | Path, title: str = "", overwrite: bool = False, inputs=None) -> None:
     """
     Generate a grouped boxplot of NMAD (or other elevation differences) per landcover class.
 
@@ -549,9 +558,11 @@ def generate_landcover_grouped_boxplot(landcover_df: pd.DataFrame, output_path: 
     None
         The plot is saved to the specified path without returning a value.
     """
-    if not overwrite and Path(output_path).exists():
-        logger.debug(f"File {output_path} already exists -> skipping.")
-        return
+    if not overwrite:
+        check = is_output_up_to_date(inputs, output_path) if inputs is not None else Path(output_path).exists()
+        if check:
+            logger.debug(f"File {output_path} is up to date -> skipping.")
+            return
 
     # order group with the mean of nmad
     code_order = landcover_df.groupby("code")["nmad"].mean().sort_values().index
@@ -574,7 +585,7 @@ def generate_landcover_grouped_boxplot(landcover_df: pd.DataFrame, output_path: 
     fig.savefig(output_path)
 
 
-def generate_landcover_boxplot(landcover_df: pd.DataFrame, output_path: str | Path, overwrite: bool = False) -> None:
+def generate_landcover_boxplot(landcover_df: pd.DataFrame, output_path: str | Path, overwrite: bool = False, inputs=None) -> None:
     """
     Generate a boxplot of mean elevation statistics grouped by landcover class.
 
@@ -594,9 +605,11 @@ def generate_landcover_boxplot(landcover_df: pd.DataFrame, output_path: str | Pa
     None
         The plot is saved to the specified path without returning a value.
     """
-    if not overwrite and Path(output_path).exists():
-        logger.debug(f"File {output_path} already exists -> skipping.")
-        return
+    if not overwrite:
+        check = is_output_up_to_date(inputs, output_path) if inputs is not None else Path(output_path).exists()
+        if check:
+            logger.debug(f"File {output_path} is up to date -> skipping.")
+            return
 
     box_data = []
     labels = []
@@ -625,7 +638,7 @@ def generate_landcover_boxplot(landcover_df: pd.DataFrame, output_path: str | Pa
     fig.savefig(output_path)
 
 
-def generate_landcover_nmad(landcover_df: pd.DataFrame, output_path: str | Path, title: str = "", overwrite: bool = False) -> None:
+def generate_landcover_nmad(landcover_df: pd.DataFrame, output_path: str | Path, title: str = "", overwrite: bool = False, inputs=None) -> None:
     """
     Generate a grouped barplot of NMAD values for each raster, separated by landcover class.
 
@@ -647,9 +660,11 @@ def generate_landcover_nmad(landcover_df: pd.DataFrame, output_path: str | Path,
     None
         The plot is saved to the specified path.
     """
-    if not overwrite and Path(output_path).exists():
-        logger.debug(f"File {output_path} already exists -> skipping.")
-        return
+    if not overwrite:
+        check = is_output_up_to_date(inputs, output_path) if inputs is not None else Path(output_path).exists()
+        if check:
+            logger.debug(f"File {output_path} is up to date -> skipping.")
+            return
 
     df_plot = landcover_df.pivot_table(
         index="landcover_label",  # x axe
@@ -683,7 +698,7 @@ def generate_landcover_nmad(landcover_df: pd.DataFrame, output_path: str | Path,
     fig.savefig(output_path)
 
 
-def generate_landcover_grouped_boxplot_from_std_dems(std_landcover_df: pd.DataFrame, output_path: str | Path, overwrite: bool = False) -> None:
+def generate_landcover_grouped_boxplot_from_std_dems(std_landcover_df: pd.DataFrame, output_path: str | Path, overwrite: bool = False, inputs=None) -> None:
     """
     Generate and save a grouped boxplot of altitude standard deviations (STD)
     by landcover class across dataset–site combinations.
@@ -714,9 +729,11 @@ def generate_landcover_grouped_boxplot_from_std_dems(std_landcover_df: pd.DataFr
         - The y-axis represents altitude standard deviation in meters.
         - The landcover labels include mean percentage values for readability.
     """
-    if not overwrite and Path(output_path).exists():
-        logger.debug(f"File {output_path} already exists -> skipping.")
-        return
+    if not overwrite:
+        check = is_output_up_to_date(inputs, output_path) if inputs is not None else Path(output_path).exists()
+        if check:
+            logger.debug(f"File {output_path} is up to date -> skipping.")
+            return
 
     df = std_landcover_df.copy()
 
@@ -763,27 +780,21 @@ def visualize_files_presence_map(directories: list[str | Path], output_path: str
     output_path : str or Path or None, optional
         If provided the plot is saved there; otherwise it is displayed interactively.
     """
-    if not overwrite and output_path is not None and Path(output_path).exists():
-        logger.debug(f"File {output_path} already exists -> skipping.")
-        return
+    directories: list[Path] = [Path(d) for d in directories if d.is_dir()]
 
-    directories: list[Path] = [Path(d) for d in directories]
+    if not overwrite and output_path is not None:
+        input_files = [f for d in directories for f in d.iterdir() if f.is_file()]
+        if is_output_up_to_date(input_files, output_path) :
+            logger.debug(f"File {output_path} is up to date -> skipping.")
+            return
     rows: dict[str, dict] = {}
 
-    expected_dir = ["dense_pointclouds", "sparse_pointclouds", "intrinsics", "extrinsics", "dems", "orthoimages"]
-
     for directory in directories:
-        if directory.is_dir():
-            # skip additional folders like "reports"
-            if directory.stem not in expected_dir:
-                logger.debug(f"Skipping folder {directory}")
-                continue
-
-            for file in directory.iterdir():
-                if file.is_file():
-                    code, metadata = parse_filename(file)
-                    row = rows.setdefault(code, {"site": metadata.get("site", ""), "dataset": metadata.get("dataset", "")})
-                    row[directory.name] = True
+        for file in directory.iterdir():
+            if file.is_file():
+                code, metadata = parse_filename(file)
+                row = rows.setdefault(code, {"site": metadata["site"], "dataset": metadata["dataset"]})
+                row[directory.name] = True
 
     df = pd.DataFrame.from_dict(rows, orient="index")
     df.index.name = "code"
@@ -839,9 +850,13 @@ def visualize_files_size_map(df: pd.DataFrame, output_path: str | Path | None = 
     output_path : str or Path or None, optional
         If provided the plot is saved there; otherwise it is displayed interactively.
     """
-    if not overwrite and output_path is not None and Path(output_path).exists():
-        logger.debug(f"File {output_path} already exists -> skipping.")
-        return
+    if not overwrite and output_path is not None:
+        file_cols = [c for c in df.columns if c.endswith("_file")]
+        inputs = pd.concat([df[c].dropna() for c in file_cols]).values if file_cols else None
+        check = is_output_up_to_date(inputs, output_path) if inputs is not None and len(inputs) > 0 else Path(output_path).exists()
+        if check:
+            logger.debug(f"File {output_path} is up to date -> skipping.")
+            return
 
     _SIZE_COLS = {
         "dense_pointcloud_file": "dense PC",

--- a/src/history/postprocessing/visualization.py
+++ b/src/history/postprocessing/visualization.py
@@ -69,7 +69,7 @@ def generate_dems_mosaic(
         return any value.
     """
     if not overwrite and is_output_up_to_date(list(dem_files_dict.values()), output_path):
-        logger.debug(f"File {output_path} already exists -> skipping.")
+        logger.debug(f"File {output_path} is up to date -> skipping.")
         return
 
     with _generate_mosaic_figure_and_axes(len(dem_files_dict), output_path) as (fig, axes):
@@ -129,7 +129,7 @@ def generate_ddems_mosaic(
         return any value.
     """
     if not overwrite and is_output_up_to_date(list(ddem_files_dict.values()), output_path):
-        logger.debug(f"File {output_path} already exists -> skipping.")
+        logger.debug(f"File {output_path} is up to date -> skipping.")
         return
 
     with _generate_mosaic_figure_and_axes(len(ddem_files_dict), output_path) as (fig, axes):
@@ -195,7 +195,7 @@ def generate_slopes_mosaic(
         return any value.
     """
     if not overwrite and is_output_up_to_date(list(dem_files_dict.values()), output_path):
-        logger.debug(f"File {output_path} already exists -> skipping.")
+        logger.debug(f"File {output_path} is up to date -> skipping.")
         return
 
     with _generate_mosaic_figure_and_axes(len(dem_files_dict), output_path) as (fig, axes):
@@ -267,7 +267,7 @@ def generate_hillshades_mosaic(
         The function saves the generated hillshade mosaic to `output_path`.
     """
     if not overwrite and is_output_up_to_date(list(dem_files_dict.values()), output_path):
-        logger.debug(f"File {output_path} already exists -> skipping.")
+        logger.debug(f"File {output_path} is up to date -> skipping.")
         return
 
     with _generate_mosaic_figure_and_axes(len(dem_files_dict), output_path) as (fig, axes):
@@ -318,7 +318,7 @@ def generate_std_dem_plots(dem_path: str | Path, output_path: str | Path, overwr
     dem_path = Path(dem_path)
 
     if not overwrite and is_output_up_to_date(dem_path, output_path):
-        logger.debug(f"File {output_path} already exists -> skipping.")
+        logger.debug(f"File {output_path} is up to date -> skipping.")
         return
 
     std_dem = _read_raster_with_max_size(dem_path)
@@ -372,8 +372,9 @@ def barplot_var(global_df: pd.DataFrame, output_path: str | Path, colname: str, 
     - Each unique combination of `site` and `dataset` is treated as a separate color group.
     - The x-axis labels correspond to the DataFrame index, rotated for readability.
     """
-    if not overwrite and Path(output_path).exists():
-        logger.debug(f"File {output_path} already exists -> skipping.")
+    inputs = global_df.file.values
+    if not overwrite and is_output_up_to_date(inputs, output_path):
+        logger.debug(f"File {output_path} is up to date -> skipping.")
         return
 
     df = global_df.dropna(subset=[colname]).copy(True)
@@ -985,7 +986,7 @@ def generate_coregistration_individual_plots(
 
         input_files = [row["ddem_before_file"], row["ddem_after_file"]]
         if not overwrite and is_output_up_to_date(input_files, output_path):
-            logger.debug(f"File {output_path} already exists -> skipping.")
+            logger.debug(f"File {output_path} is up to date -> skipping.")
             continue
 
         # open the raw dDEM and the coregistered dDEM

--- a/src/history/postprocessing/visualization.py
+++ b/src/history/postprocessing/visualization.py
@@ -7,8 +7,6 @@ from contextlib import contextmanager
 import logging
 from pathlib import Path
 from typing import Generator
-import os
-
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -20,7 +18,7 @@ from matplotlib.figure import Figure
 from matplotlib.patches import Patch
 from rasterio.enums import Resampling
 
-from history.postprocessing.io import parse_filename
+from history.postprocessing.io import is_output_up_to_date, parse_filename
 
 logger = logging.getLogger(__name__)
 
@@ -70,13 +68,9 @@ def generate_dems_mosaic(
         The function saves the generated figure to ``output_path`` and does not
         return any value.
     """
-    # If output figure exists and is newer than all input files, does not plot
-    if os.path.exists(output_path) and (not overwrite):
-        all_input_mtimes = [os.path.getmtime(fname) for fname in list(dem_files_dict.values())]
-        output_mtime = os.path.getmtime(output_path)
-        if output_mtime > np.max(all_input_mtimes):
-            logger.debug(f"File {output_path} already exists -> skipping.")
-            return
+    if not overwrite and is_output_up_to_date(list(dem_files_dict.values()), output_path):
+        logger.debug(f"File {output_path} already exists -> skipping.")
+        return
 
     with _generate_mosaic_figure_and_axes(len(dem_files_dict), output_path) as (fig, axes):
         for i, (subtitle, file) in enumerate(sorted(dem_files_dict.items())):
@@ -134,14 +128,10 @@ def generate_ddems_mosaic(
         The function saves the generated mosaic to `output_path` and does not
         return any value.
     """
-    # If output figure exists and is newer than all input files, does not plot
-    if os.path.exists(output_path) and (not overwrite):
-        all_input_mtimes = [os.path.getmtime(fname) for fname in list(ddem_files_dict.values())]
-        output_mtime = os.path.getmtime(output_path)
-        if output_mtime > np.max(all_input_mtimes):
-            logger.debug(f"File {output_path} already exists -> skipping.")
-            return
-        
+    if not overwrite and is_output_up_to_date(list(ddem_files_dict.values()), output_path):
+        logger.debug(f"File {output_path} already exists -> skipping.")
+        return
+
     with _generate_mosaic_figure_and_axes(len(ddem_files_dict), output_path) as (fig, axes):
         for i, (subtitle, file) in enumerate(sorted(ddem_files_dict.items())):
             try:
@@ -204,13 +194,9 @@ def generate_slopes_mosaic(
         The function saves the generated mosaic to `output_path` and does not
         return any value.
     """
-    # If output figure exists and is newer than all input files, does not plot
-    if os.path.exists(output_path) and (not overwrite):
-        all_input_mtimes = [os.path.getmtime(fname) for fname in list(dem_files_dict.values())]
-        output_mtime = os.path.getmtime(output_path)
-        if output_mtime > np.max(all_input_mtimes):
-            logger.debug(f"File {output_path} already exists -> skipping.")
-            return
+    if not overwrite and is_output_up_to_date(list(dem_files_dict.values()), output_path):
+        logger.debug(f"File {output_path} already exists -> skipping.")
+        return
 
     with _generate_mosaic_figure_and_axes(len(dem_files_dict), output_path) as (fig, axes):
         for i, (subtitle, file) in enumerate(sorted(dem_files_dict.items())):
@@ -280,13 +266,9 @@ def generate_hillshades_mosaic(
     None
         The function saves the generated hillshade mosaic to `output_path`.
     """
-    # If output figure exists and is newer than all input files, does not plot
-    if os.path.exists(output_path) and (not overwrite):
-        all_input_mtimes = [os.path.getmtime(fname) for fname in list(dem_files_dict.values())]
-        output_mtime = os.path.getmtime(output_path)
-        if output_mtime > np.max(all_input_mtimes):
-            logger.debug(f"File {output_path} already exists -> skipping.")
-            return
+    if not overwrite and is_output_up_to_date(list(dem_files_dict.values()), output_path):
+        logger.debug(f"File {output_path} already exists -> skipping.")
+        return
 
     with _generate_mosaic_figure_and_axes(len(dem_files_dict), output_path) as (fig, axes):
         for i, (subtitle, file) in enumerate(sorted(dem_files_dict.items())):
@@ -313,7 +295,7 @@ def generate_hillshades_mosaic(
         fig.suptitle(title, fontsize=16)
 
 
-def generate_std_dem_plots(dem_path: str | Path, output_path: str | Path) -> None:
+def generate_std_dem_plots(dem_path: str | Path, output_path: str | Path, overwrite: bool = False) -> None:
     """
     Generate and save a heatmap of the elevation standard deviation from a DEM.
 
@@ -333,8 +315,11 @@ def generate_std_dem_plots(dem_path: str | Path, output_path: str | Path) -> Non
     None
         Saves the plot to `output_path` without returning a value.
     """
-    # create the output directory if needed
     dem_path = Path(dem_path)
+
+    if not overwrite and is_output_up_to_date(dem_path, output_path):
+        logger.debug(f"File {output_path} already exists -> skipping.")
+        return
 
     std_dem = _read_raster_with_max_size(dem_path)
 
@@ -358,7 +343,7 @@ def generate_std_dem_plots(dem_path: str | Path, output_path: str | Path) -> Non
 #######################################################################################################################
 
 
-def barplot_var(global_df: pd.DataFrame, output_path: str | Path, colname: str, title: str = "") -> None:
+def barplot_var(global_df: pd.DataFrame, output_path: str | Path, colname: str, title: str = "", overwrite: bool = False) -> None:
     """
     Generate a grouped bar plot for a specified column in a DataFrame and save it to a file.
 
@@ -387,6 +372,10 @@ def barplot_var(global_df: pd.DataFrame, output_path: str | Path, colname: str, 
     - Each unique combination of `site` and `dataset` is treated as a separate color group.
     - The x-axis labels correspond to the DataFrame index, rotated for readability.
     """
+    if not overwrite and Path(output_path).exists():
+        logger.debug(f"File {output_path} already exists -> skipping.")
+        return
+
     df = global_df.dropna(subset=[colname]).copy(True)
 
     # Créer la colonne groupe
@@ -431,7 +420,7 @@ def barplot_var(global_df: pd.DataFrame, output_path: str | Path, colname: str, 
     fig.savefig(output_path)
 
 
-def generate_plot_coreg_shifts(df: pd.DataFrame, output_path: str | Path, title: str = "") -> None:
+def generate_plot_coreg_shifts(df: pd.DataFrame, output_path: str | Path, title: str = "", overwrite: bool = False) -> None:
     """
     Generate a bar plot of coregistration shifts (X, Y, Z) from a DataFrame and save it to a file.
 
@@ -458,6 +447,10 @@ def generate_plot_coreg_shifts(df: pd.DataFrame, output_path: str | Path, title:
     - Rows with NaN values in any of the shift columns are ignored.
     - Shifts are displayed in meters with labels above each bar.
     """
+    if not overwrite and Path(output_path).exists():
+        logger.debug(f"File {output_path} already exists -> skipping.")
+        return
+
     colnames = ["coreg_shift_x", "coreg_shift_y", "coreg_shift_z"]
     dropped_df = (
         df.dropna(subset=colnames)
@@ -483,7 +476,7 @@ def generate_plot_coreg_shifts(df: pd.DataFrame, output_path: str | Path, title:
     fig.savefig(output_path)
 
 
-def generate_plot_nmad_before_vs_after(df: pd.DataFrame, output_path: str | Path, title: str = "") -> None:
+def generate_plot_nmad_before_vs_after(df: pd.DataFrame, output_path: str | Path, title: str = "", overwrite: bool = False) -> None:
     """
     Generate a bar plot comparing NMAD values before and after DEM coregistration.
 
@@ -505,6 +498,10 @@ def generate_plot_nmad_before_vs_after(df: pd.DataFrame, output_path: str | Path
     None
         The plot is saved to the specified path without returning a value.
     """
+    if not overwrite and Path(output_path).exists():
+        logger.debug(f"File {output_path} already exists -> skipping.")
+        return
+
     colnames = ["ddem_before_nmad", "ddem_after_nmad"]
     dropped_df = df.dropna(subset=colnames).sort_values(by="ddem_after_nmad")
     if len(dropped_df) == 0:
@@ -529,7 +526,7 @@ def generate_plot_nmad_before_vs_after(df: pd.DataFrame, output_path: str | Path
 #######################################################################################################################
 
 
-def generate_landcover_grouped_boxplot(landcover_df: pd.DataFrame, output_path: str | Path, title: str = "") -> None:
+def generate_landcover_grouped_boxplot(landcover_df: pd.DataFrame, output_path: str | Path, title: str = "", overwrite: bool = False) -> None:
     """
     Generate a grouped boxplot of NMAD (or other elevation differences) per landcover class.
 
@@ -551,6 +548,10 @@ def generate_landcover_grouped_boxplot(landcover_df: pd.DataFrame, output_path: 
     None
         The plot is saved to the specified path without returning a value.
     """
+    if not overwrite and Path(output_path).exists():
+        logger.debug(f"File {output_path} already exists -> skipping.")
+        return
+
     # order group with the mean of nmad
     code_order = landcover_df.groupby("code")["nmad"].mean().sort_values().index
     ordered_df = landcover_df.set_index("code").loc[code_order].reset_index()
@@ -572,7 +573,7 @@ def generate_landcover_grouped_boxplot(landcover_df: pd.DataFrame, output_path: 
     fig.savefig(output_path)
 
 
-def generate_landcover_boxplot(landcover_df: pd.DataFrame, output_path: str | Path) -> None:
+def generate_landcover_boxplot(landcover_df: pd.DataFrame, output_path: str | Path, overwrite: bool = False) -> None:
     """
     Generate a boxplot of mean elevation statistics grouped by landcover class.
 
@@ -592,6 +593,10 @@ def generate_landcover_boxplot(landcover_df: pd.DataFrame, output_path: str | Pa
     None
         The plot is saved to the specified path without returning a value.
     """
+    if not overwrite and Path(output_path).exists():
+        logger.debug(f"File {output_path} already exists -> skipping.")
+        return
+
     box_data = []
     labels = []
     for lc_label, lc_group in landcover_df.groupby("landcover_label"):
@@ -619,7 +624,7 @@ def generate_landcover_boxplot(landcover_df: pd.DataFrame, output_path: str | Pa
     fig.savefig(output_path)
 
 
-def generate_landcover_nmad(landcover_df: pd.DataFrame, output_path: str | Path, title: str = "") -> None:
+def generate_landcover_nmad(landcover_df: pd.DataFrame, output_path: str | Path, title: str = "", overwrite: bool = False) -> None:
     """
     Generate a grouped barplot of NMAD values for each raster, separated by landcover class.
 
@@ -641,6 +646,10 @@ def generate_landcover_nmad(landcover_df: pd.DataFrame, output_path: str | Path,
     None
         The plot is saved to the specified path.
     """
+    if not overwrite and Path(output_path).exists():
+        logger.debug(f"File {output_path} already exists -> skipping.")
+        return
+
     df_plot = landcover_df.pivot_table(
         index="landcover_label",  # x axe
         columns="code",  # one color per bar
@@ -673,7 +682,7 @@ def generate_landcover_nmad(landcover_df: pd.DataFrame, output_path: str | Path,
     fig.savefig(output_path)
 
 
-def generate_landcover_grouped_boxplot_from_std_dems(std_landcover_df: pd.DataFrame, output_path: str | Path) -> None:
+def generate_landcover_grouped_boxplot_from_std_dems(std_landcover_df: pd.DataFrame, output_path: str | Path, overwrite: bool = False) -> None:
     """
     Generate and save a grouped boxplot of altitude standard deviations (STD)
     by landcover class across dataset–site combinations.
@@ -704,6 +713,10 @@ def generate_landcover_grouped_boxplot_from_std_dems(std_landcover_df: pd.DataFr
         - The y-axis represents altitude standard deviation in meters.
         - The landcover labels include mean percentage values for readability.
     """
+    if not overwrite and Path(output_path).exists():
+        logger.debug(f"File {output_path} already exists -> skipping.")
+        return
+
     df = std_landcover_df.copy()
 
     # first group the dataset + site
@@ -733,7 +746,7 @@ def generate_landcover_grouped_boxplot_from_std_dems(std_landcover_df: pd.DataFr
 #######################################################################################################################
 
 
-def visualize_files_presence_map(directories: list[str | Path], output_path: str | Path | None = None) -> None:
+def visualize_files_presence_map(directories: list[str | Path], output_path: str | Path | None = None, overwrite: bool = False) -> None:
     """
     Create a visual presence/absence map of files across multiple directories.
 
@@ -749,6 +762,10 @@ def visualize_files_presence_map(directories: list[str | Path], output_path: str
     output_path : str or Path or None, optional
         If provided the plot is saved there; otherwise it is displayed interactively.
     """
+    if not overwrite and output_path is not None and Path(output_path).exists():
+        logger.debug(f"File {output_path} already exists -> skipping.")
+        return
+
     directories: list[Path] = [Path(d) for d in directories]
     rows: dict[str, dict] = {}
 
@@ -803,7 +820,7 @@ def visualize_files_presence_map(directories: list[str | Path], output_path: str
         plt.close()
 
 
-def visualize_files_size_map(df: pd.DataFrame, output_path: str | Path | None = None) -> None:
+def visualize_files_size_map(df: pd.DataFrame, output_path: str | Path | None = None, overwrite: bool = False) -> None:
     """
     Create a visual file-size matrix for submission files.
 
@@ -821,6 +838,10 @@ def visualize_files_size_map(df: pd.DataFrame, output_path: str | Path | None = 
     output_path : str or Path or None, optional
         If provided the plot is saved there; otherwise it is displayed interactively.
     """
+    if not overwrite and output_path is not None and Path(output_path).exists():
+        logger.debug(f"File {output_path} already exists -> skipping.")
+        return
+
     _SIZE_COLS = {
         "dense_pointcloud_file": "dense PC",
         "sparse_pointcloud_file": "sparse PC",
@@ -962,42 +983,46 @@ def generate_coregistration_individual_plots(
     for code, row in dropped_df.iterrows():
         output_path = output_directory / f"{code}.png"
 
-        if not output_path.exists() or overwrite:
-            # open the raw dDEM and the coregistered dDEM
-            ddem_before = _read_raster_with_max_size(row["ddem_before_file"])
-            ddem_after = _read_raster_with_max_size(row["ddem_after_file"])
+        input_files = [row["ddem_before_file"], row["ddem_after_file"]]
+        if not overwrite and is_output_up_to_date(input_files, output_path):
+            logger.debug(f"File {output_path} already exists -> skipping.")
+            continue
 
-            ddem_before = np.clip(ddem_before, vmin, vmax)
-            ddem_after = np.clip(ddem_after, vmin, vmax)
+        # open the raw dDEM and the coregistered dDEM
+        ddem_before = _read_raster_with_max_size(row["ddem_before_file"])
+        ddem_after = _read_raster_with_max_size(row["ddem_after_file"])
 
-            # create the figure
-            fig = Figure(figsize=(10, 5), constrained_layout=True)
-            axes = fig.subplots(1, 2)
+        ddem_before = np.clip(ddem_before, vmin, vmax)
+        ddem_after = np.clip(ddem_after, vmin, vmax)
 
-            # add the dDEMs and their titles
-            axes[0].imshow(ddem_before, cmap="coolwarm", vmin=vmin, vmax=vmax)
-            axes[0].axis("off")
-            axes[0].set_title(
-                f"dDEM before coregistration \n(mean: {row['ddem_before_mean']:.3f}, med: {row['ddem_before_median']:.3f}, nmad: {row['ddem_before_nmad']:.3f})"
-            )
+        # create the figure
+        fig = Figure(figsize=(10, 5), constrained_layout=True)
+        axes = fig.subplots(1, 2)
 
-            axes[1].imshow(ddem_after, cmap="coolwarm", vmin=vmin, vmax=vmax)
-            axes[1].axis("off")
-            axes[1].set_title(
-                f"dDEM after coregistration \n(mean: {row['ddem_after_mean']:.3f}, med: {row['ddem_after_median']:.3f}, nmad: {row['ddem_after_nmad']:.3f})"
-            )
+        # add the dDEMs and their titles
+        axes[0].imshow(ddem_before, cmap="coolwarm", vmin=vmin, vmax=vmax)
+        axes[0].axis("off")
+        axes[0].set_title(
+            f"dDEM before coregistration \n(mean: {row['ddem_before_mean']:.3f}, med: {row['ddem_before_median']:.3f}, nmad: {row['ddem_before_nmad']:.3f})"
+        )
 
-            # add a global color bar
-            cbar = fig.colorbar(
-                ScalarMappable(cmap="coolwarm", norm=plt.Normalize(vmin=vmin, vmax=vmax)),
-                ax=axes,
-                orientation="vertical",
-                fraction=0.03,
-                pad=0.02,
-            )
-            cbar.set_label("Altitude difference(m)")
+        axes[1].imshow(ddem_after, cmap="coolwarm", vmin=vmin, vmax=vmax)
+        axes[1].axis("off")
+        axes[1].set_title(
+            f"dDEM after coregistration \n(mean: {row['ddem_after_mean']:.3f}, med: {row['ddem_after_median']:.3f}, nmad: {row['ddem_after_nmad']:.3f})"
+        )
 
-            fig.savefig(output_path)
+        # add a global color bar
+        cbar = fig.colorbar(
+            ScalarMappable(cmap="coolwarm", norm=plt.Normalize(vmin=vmin, vmax=vmax)),
+            ax=axes,
+            orientation="vertical",
+            fraction=0.03,
+            pad=0.02,
+        )
+        cbar.set_label("Altitude difference(m)")
+
+        fig.savefig(output_path)
 
 
 #######################################################################################################################

--- a/src/history/postprocessing/visualization.py
+++ b/src/history/postprocessing/visualization.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 import logging
 from pathlib import Path
 from typing import Generator
+import os
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -34,6 +35,7 @@ def generate_dems_mosaic(
     vmin: float,
     vmax: float,
     title: str = "",
+    overwrite: bool = False,
 ) -> None:
     """
     Generate a mosaic figure composed of multiple DEM images.
@@ -59,6 +61,8 @@ def generate_dems_mosaic(
     title : str, optional
         A global title displayed above the entire mosaic figure. Default is an
         empty string.
+    overwrite : bool, optional
+        Set to True to force overwriting existing output. Default is False.
 
     Returns
     -------
@@ -66,6 +70,14 @@ def generate_dems_mosaic(
         The function saves the generated figure to ``output_path`` and does not
         return any value.
     """
+    # If output figure exists and is newer than all input files, does not plot
+    if os.path.exists(output_path) and (not overwrite):
+        all_input_mtimes = [os.path.getmtime(fname) for fname in list(dem_files_dict.values())]
+        output_mtime = os.path.getmtime(output_path)
+        if output_mtime > np.max(all_input_mtimes):
+            logger.debug(f"File {output_path} already exists -> skipping.")
+            return
+
     with _generate_mosaic_figure_and_axes(len(dem_files_dict), output_path) as (fig, axes):
         for i, (subtitle, file) in enumerate(dem_files_dict.items()):
             dem = _read_raster_with_max_size(file)
@@ -89,6 +101,7 @@ def generate_ddems_mosaic(
     vmin: float = -10,
     vmax: float = 10,
     title: str = "",
+    overwrite: bool = False,
 ) -> None:
     """
     Generate a mosaic of dDEM (differential DEM) rasters and save it as an image.
@@ -112,6 +125,8 @@ def generate_ddems_mosaic(
         Maximum value for clipping and colormap normalization. Default is 10.
     title : str, optional
         Global title for the mosaic figure. Default is an empty string.
+    overwrite : bool, optional
+        Set to True to force overwriting existing output. Default is False.
 
     Returns
     -------
@@ -119,6 +134,14 @@ def generate_ddems_mosaic(
         The function saves the generated mosaic to `output_path` and does not
         return any value.
     """
+    # If output figure exists and is newer than all input files, does not plot
+    if os.path.exists(output_path) and (not overwrite):
+        all_input_mtimes = [os.path.getmtime(fname) for fname in list(ddem_files_dict.values())]
+        output_mtime = os.path.getmtime(output_path)
+        if output_mtime > np.max(all_input_mtimes):
+            logger.debug(f"File {output_path} already exists -> skipping.")
+            return
+        
     with _generate_mosaic_figure_and_axes(len(ddem_files_dict), output_path) as (fig, axes):
         for i, (subtitle, file) in enumerate(ddem_files_dict.items()):
             try:
@@ -142,11 +165,12 @@ def generate_ddems_mosaic(
 
 
 def generate_slopes_mosaic(
-    ddem_files_dict: dict[str, list[str | Path]],
+    dem_files_dict: dict[str, list[str | Path]],
     output_path: str | Path,
     vmin: float = 0,
     vmax: float = 15,
     title: str = "",
+    overwrite: bool = False,
 ) -> None:
     """
     Generate a mosaic of slope maps derived from elevation rasters.
@@ -160,7 +184,7 @@ def generate_slopes_mosaic(
 
     Parameters
     ----------
-    ddem_files_dict : dict[str, list[str | Path]]
+    dem_files_dict : dict[str, list[str | Path]]
         A dictionary mapping subplot titles to one or more elevation raster files
         from which slopes will be computed.
     output_path : str | Path
@@ -171,6 +195,8 @@ def generate_slopes_mosaic(
         Maximum value for clipping and colormap normalization. Default is 15.
     title : str, optional
         Global title for the mosaic figure. Default is an empty string.
+    overwrite : bool, optional
+        Set to True to force overwriting existing output. Default is False.
 
     Returns
     -------
@@ -178,8 +204,16 @@ def generate_slopes_mosaic(
         The function saves the generated mosaic to `output_path` and does not
         return any value.
     """
-    with _generate_mosaic_figure_and_axes(len(ddem_files_dict), output_path) as (fig, axes):
-        for i, (subtitle, file) in enumerate(ddem_files_dict.items()):
+    # If output figure exists and is newer than all input files, does not plot
+    if os.path.exists(output_path) and (not overwrite):
+        all_input_mtimes = [os.path.getmtime(fname) for fname in list(dem_files_dict.values())]
+        output_mtime = os.path.getmtime(output_path)
+        if output_mtime > np.max(all_input_mtimes):
+            logger.debug(f"File {output_path} already exists -> skipping.")
+            return
+
+    with _generate_mosaic_figure_and_axes(len(dem_files_dict), output_path) as (fig, axes):
+        for i, (subtitle, file) in enumerate(dem_files_dict.items()):
             dem = _read_raster_with_max_size(file)
 
             with rasterio.open(file) as src:
@@ -207,11 +241,12 @@ def generate_slopes_mosaic(
 
 
 def generate_hillshades_mosaic(
-    ddem_files_dict: dict[str, list[str | Path]],
+    dem_files_dict: dict[str, list[str | Path]],
     output_path: str | Path,
     vmin: float = 0,
     vmax: float = 1,
     title: str = "",
+    overwrite: bool = False,
 ) -> None:
     """
     Generate a mosaic of hillshade visualizations from elevation rasters.
@@ -226,7 +261,7 @@ def generate_hillshades_mosaic(
 
     Parameters
     ----------
-    ddem_files_dict : dict[str, list[str | Path]]
+    dem_files_dict : dict[str, list[str | Path]]
         A dictionary mapping subplot titles to elevation raster file paths
         from which hillshades will be computed.
     output_path : str | Path
@@ -237,14 +272,24 @@ def generate_hillshades_mosaic(
         Maximum value for colormap normalization. Default is 1.
     title : str, optional
         Global title for the hillshade mosaic. Default is an empty string.
+    overwrite : bool, optional
+        Set to True to force overwriting existing output. Default is False.
 
     Returns
     -------
     None
         The function saves the generated hillshade mosaic to `output_path`.
     """
-    with _generate_mosaic_figure_and_axes(len(ddem_files_dict), output_path) as (fig, axes):
-        for i, (subtitle, file) in enumerate(ddem_files_dict.items()):
+    # If output figure exists and is newer than all input files, does not plot
+    if os.path.exists(output_path) and (not overwrite):
+        all_input_mtimes = [os.path.getmtime(fname) for fname in list(dem_files_dict.values())]
+        output_mtime = os.path.getmtime(output_path)
+        if output_mtime > np.max(all_input_mtimes):
+            logger.debug(f"File {output_path} already exists -> skipping.")
+            return
+
+    with _generate_mosaic_figure_and_axes(len(dem_files_dict), output_path) as (fig, axes):
+        for i, (subtitle, file) in enumerate(dem_files_dict.items()):
             dem = _read_raster_with_max_size(file)
 
             with rasterio.open(file) as src:

--- a/src/history/postprocessing/visualization.py
+++ b/src/history/postprocessing/visualization.py
@@ -707,8 +707,15 @@ def visualize_files_presence_map(directories: list[str | Path], output_path: str
     directories: list[Path] = [Path(d) for d in directories]
     rows: dict[str, dict] = {}
 
+    expected_dir = ["dense_pointclouds", "sparse_pointclouds", "intrinsics", "extrinsics", "dems", "orthoimages"]
+
     for directory in directories:
         if directory.is_dir():
+            # skip additional folders like "reports"
+            if directory.stem not in expected_dir:
+                logger.debug(f"Skipping folder {directory}")
+                continue
+
             for file in directory.iterdir():
                 if file.is_file():
                     code, metadata = parse_filename(file)


### PR DESCRIPTION
This PR updates many of the postprocessing steps to make it easier to identify errors in submissions and automatically generate a report of the main figures:
- update file naming convention to the latest v2 requirements
- allow team tags of 3-6 characters
- filenaming check is done consistently across all postprocessing steps and the function `parse_filename` now raises  `FilenameParseError`, which provide a clearer error.
- check for duplicated files (from multiple archives) > the function `scan_submissions` include a duplicate checking.
- add renaming step for files not following the convention > A renaming step is added to the config (work with regex), it's used when the symlinks are generated.
- Add a CLI step "generate_pdf" which generates a pdf report by concatenating all png figures.
- add a pipeline step to check received submissions against planned submissions
- add verbose option to CLI subcommand run
- add gdown dependency

**TODO:**

- [ ] add Sankey diagram generation : integrate preliminary script into pipeline, using downloaded planned experiment file